### PR TITLE
Add no resources page

### DIFF
--- a/templates/details/_details-tab-navigation.html
+++ b/templates/details/_details-tab-navigation.html
@@ -5,11 +5,9 @@
         <a href="/{{ package.name }}{% if channel_requested %}?channel={{ channel_requested }}{% endif %}" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'overview' or current_tab == 'docs' %}aria-selected="true" {% endif %}>Description</a>
       </li>
       {% if package.type == "charm" %}
-      {% if package['default-release']['resources'] %}
       <li class="p-tabs__item" role="presentation">
         <a href="/{{ package.name }}/resources{% if channel_requested %}?channel={{ channel_requested }}{% endif %}" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'resources' %}aria-selected="true" {% endif %}>Resources</a>
       </li>
-      {% endif %}
       <li class="p-tabs__item" role="presentation">
         <a href="/{{ package.name }}/libraries{% if channel_requested %}?channel={{ channel_requested }}{% endif %}" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'libraries' %}aria-selected="true" {% endif %}>Libraries</a>
       </li>

--- a/templates/details/actions.html
+++ b/templates/details/actions.html
@@ -69,7 +69,7 @@
           <img src="https://assets.ubuntu.com/v1/3234f995-Generic_chamhub_NoDocs.svg" alt="" width="121" height="121">
         </div>
         <div class="col-9 charm-empty-docs-content">
-          <h4>No actions have been added yet</h4>
+          <h4>No actions have been added for this charm</h4>
           <p>Actions are executables associated with a charm that may be invoked by the user.</p>
           <p class="u-no-margin--bottom"><a class="p-button--positive u-no-margin--bottom" href="https://juju.is/docs/charm-writing/actions">Learn more about working with actions</a></p>
         </div>

--- a/templates/details/no-resources.html
+++ b/templates/details/no-resources.html
@@ -1,4 +1,4 @@
-{% set current_tab = "libraries" %}
+{% set current_tab = "resources" %}
 
 {% extends '/details/details_layout.html' %}
 
@@ -9,9 +9,9 @@
         <img src="https://assets.ubuntu.com/v1/3234f995-Generic_chamhub_NoDocs.svg" alt="" width="121" height="121">
       </div>
       <div class="col-9 charm-empty-docs-content">
-        <h4>No libraries have been added for this charm</h4>
-        <p>Charm libraries provide a means for charm developers to make the implementation of any relation they define as simple as possible for other developers.</p>
-        <p class="u-no-margin--bottom"><a class="p-button--positive u-no-margin--bottom" href="https://juju.is/docs/sdk/libraries">Learn how to add libraries to a charm</a></p>
+        <h4>No resources have been added for this charm</h4>
+        <p>A resource is additional content that a charm can make use of, or may require, to run.</p>
+        <p class="u-no-margin--bottom"><a class="p-button--positive u-no-margin--bottom" href="https://juju.is/docs/sdk/resources">Learn how to manage charm resources</a></p>
       </div>
     </div>
   </div>

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -547,7 +547,7 @@ def details_resources(entity_name):
         name = package["default-release"]["resources"][0]["name"]
         return redirect(f"/{entity_name}/resources/{name}")
     else:
-        abort(404)
+        return render_template("details/no-resources.html", package=package)
 
 
 @store.route(


### PR DESCRIPTION
## Done
- Added an empty state if a charm has no resources
- Updated the empty state for no action and no library view

## QA
- Go to https://charmhub-io-1393.demos.haus/discourse-charmers-discourse-k8s/resources
- Check that there is an empty state
- Go to https://charmhub-io-1393.demos.haus/discourse-charmers-discourse-k8s/libraries
- Check that there is an empty state
- Go to https://charmhub-io-1393.demos.haus/discourse-charmers-discourse-k8s/actions
- Check that there is an empty state 

## Issue
Fixes https://github.com/canonical/charmhub.io/issues/1392