### PR TITLE
Prevent 404 on no resource page

### DIFF
--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -563,14 +563,14 @@ def details_resource(entity_name, resource_name):
     resources = package["default-release"]["resources"]
 
     if not resources:
-        abort(404)
+        return redirect(f"/{entity_name}/resources")
 
     resource = next(
         (item for item in resources if item["name"] == resource_name), None
     )
 
     if not resource:
-        abort(404)
+        return redirect(f"/{entity_name}/resources")
 
     # Get OCI image details
     if resource["type"] == "oci-image":


### PR DESCRIPTION
## Done
Prevent a 404 on missing resource pages

## QA
- Go to https://charmhub-io-1394.demos.haus/slurmd/resources/singularity-deb
- Check that you are taken to the empty resources page and not a 404