### PR TITLE
Fix section heading not scrolling into view

### DIFF
--- a/templates/details/configure-charm.html
+++ b/templates/details/configure-charm.html
@@ -68,7 +68,7 @@
   function scrollToSection() {
     const hash = window.location.hash;
       const el = document.querySelector(hash);
-      const offset = 110;
+      const offset = 165;
       const elPosition = el.getBoundingClientRect().top;
       const offsetPosition = elPosition + window.pageYOffset - offset;
       window.scrollTo({ top: offsetPosition });

--- a/templates/details/configure-charm.html
+++ b/templates/details/configure-charm.html
@@ -64,5 +64,19 @@
 
   // Fix to see the content under the sticky nav when you navigate using # on the docstring page
   window.addEventListener("hashchange", () => { scrollBy(0, -55) })
+
+  function scrollToSection() {
+    const hash = window.location.hash;
+      const el = document.querySelector(hash);
+      const offset = 110;
+      const elPosition = el.getBoundingClientRect().top;
+      const offsetPosition = elPosition + window.pageYOffset - offset;
+      window.scrollTo({ top: offsetPosition });
+      window.removeEventListener("load", scrollToSection);
+  }
+
+  if (window.location.hash) {
+    window.addEventListener("load", scrollToSection)
+  }
 </script>
 {% endblock%}


### PR DESCRIPTION
## Done
Fixed section headings being hidden under the sticky header when opened in a new tab

## How to QA
- Go to a charm configure page, e.g. https://charmhub-io-1397.demos.haus/ceph-osd/configure
- Open one of the links in the sidebar in a new tab
- Check that the heading for that section isn't hidden under the sticky header

## Issue / Card
Fixes #1396
