### PR TITLE
Get interfaces data from GitHub and parse markdown file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ pymacaroons==0.13.0
 python-slugify==6.1.1
 ruamel.yaml.clib==0.2.2
 ruamel.yaml==0.16.12
+PyGithub==1.55

--- a/templates/interfaces/index.html
+++ b/templates/interfaces/index.html
@@ -1,0 +1,33 @@
+{% extends 'base_layout.html' %}
+
+{% block title %}Interfaces{% endblock %}
+{% block meta_description %}-{% endblock %}
+
+{% block content %}
+
+<section class="p-strip--light is-shallow u-no-padding--bottom">
+  <div class="row">
+    <div class="col-4">
+      <h1>Interfaces</h1>
+    </div>
+    <div class="col-8">
+      <p>Lorem ipsum vitae. This will be intro text about what are interfaces. Similiar to what we have for topic pages.</p>
+      <p>Most of the content of these pages can be collaboratively discussed and changed. Help us improve these pages by clicking the button below.</p>
+      <p>
+        <a href="https://github.com/canonical/charm-relation-interfaces" class="p-button--positive">Contribute</a>
+      </p>
+    </div>
+  </div>
+</section>
+
+Table with data from /interfaces.json
+{% endblock %}
+
+{% block page_scripts %}
+  <script src="{{ versioned_static('js/dist/topics.js') }}" defer></script>
+  <script>
+    window.addEventListener("DOMContentLoaded", () => {
+      new charmhub.topics.initTopicFilters();
+    });
+  </script>
+{% endblock %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -11,6 +11,7 @@ from webapp.login.views import login
 from webapp.topics.views import topics
 from webapp.publisher.views import publisher
 from webapp.store.views import store
+from webapp.interfaces.views import interfaces
 
 app = FlaskBase(
     __name__,
@@ -30,6 +31,7 @@ app.register_blueprint(publisher)
 app.register_blueprint(store)
 app.register_blueprint(login)
 app.register_blueprint(topics)
+app.register_blueprint(interfaces)
 
 
 @app.route("/account.json")

--- a/webapp/interfaces/logic.py
+++ b/webapp/interfaces/logic.py
@@ -1,0 +1,86 @@
+def find_between(s, first, last):
+    try:
+        start = s.index(first) + len(first)
+        end = s.index(last, start)
+        return s[start:end]
+    except ValueError:
+        return ""
+
+
+def get_interfaces_from_mrkd_table(content):
+    """
+    This function will return a list of interfaces from
+    a Markdown table. The table needs to start with
+    "| Interface"
+    """
+    table_content = content.split("\n## Interfaces")[-1].strip("\n")
+    lines = table_content.split("\n")
+
+    data = []
+    keys = []
+
+    # Get data from table
+    for i, l in enumerate(lines):
+        if i == 0:
+            keys = [
+                _i.strip().lower().replace(" ", "_") for _i in l.split("|")
+            ]
+        elif i == 1 or not l.startswith("|"):
+            continue
+        else:
+            data.append(
+                {
+                    keys[_i]: v.strip()
+                    for _i, v in enumerate(l.split("|"))
+                    if _i > 0 and _i < len(keys) - 1
+                }
+            )
+
+    interfaces = []
+
+    # Curate data for the interface
+    for interface in data:
+        name_data = interface["interface"]
+
+        if "[" in name_data:
+            name = find_between(name_data, "[", "]").replace("`", "")
+            readme_path = find_between(name_data, "(", ")")
+        else:
+            name = name_data
+            readme_path = None
+
+        version = None
+
+        if "/" in name:
+            splitted_name = name.split("/")
+            version = splitted_name[1].replace("v", "")
+            name = splitted_name[0]
+
+        if not version and readme_path:
+            version = readme_path.split("/")[2].replace("v", "")
+
+        if "live" in interface["status"].lower():
+            status = "Live"
+        else:
+            status = "Draft"
+
+        interfaces.append(
+            {
+                "name": name,
+                "readme_path": readme_path,
+                "version": version,
+                "status": status,
+            }
+        )
+
+    return interfaces
+
+
+def get_short_description_from_readme(readme):
+    lines = readme.split("\n")
+
+    for line in lines:
+        if line and line[0].isalpha():
+            return line
+
+    return None

--- a/webapp/interfaces/views.py
+++ b/webapp/interfaces/views.py
@@ -1,0 +1,56 @@
+from flask import Blueprint, render_template
+from github import Github
+
+from webapp.interfaces.logic import (
+    get_interfaces_from_mrkd_table,
+    get_short_description_from_readme,
+)
+
+
+interfaces = Blueprint(
+    "interfaces",
+    __name__,
+    template_folder="/templates",
+    static_folder="/static",
+)
+
+# Todo create token
+github_client = Github()
+
+
+@interfaces.route("/interfaces.json")
+def interfaces_json():
+    repo = github_client.get_repo("canonical/charm-relation-interfaces")
+    readme = repo.get_contents("README.md").decoded_content.decode("utf-8")
+
+    interfaces = get_interfaces_from_mrkd_table(readme)
+
+    for i, inter in enumerate(interfaces):
+        try:
+            interface_readme = repo.get_contents(
+                inter["readme_path"]
+            ).decoded_content.decode("utf-8")
+            description = get_short_description_from_readme(interface_readme)
+        except Exception:
+            # Some draft interfaces are missing a readme
+            description = ""
+
+        interfaces[i]["description"] = description
+
+    return {
+        "interfaces": interfaces,
+        "size": len(interfaces),
+    }
+
+
+@interfaces.route("/interfaces")
+def all_interfaces():
+    return render_template("interfaces/index.html")
+
+
+@interfaces.route("/interfaces/<string:interface_slug>")
+def interface_page(interface_slug, path=None):
+
+    context = {}
+
+    return render_template("interfaces/document.html", **context)


### PR DESCRIPTION
## Done

Get interfaces data from GitHub and parse the root README file and README for each interface

## How to QA
Check https://charmhub-io-1420.demos.haus/interfaces
Check https://charmhub-io-1420.demos.haus/interfaces.json data is acceptable and make sense with https://github.com/canonical/charm-relation-interfaces#interfaces

## Issue / Card
Fixes https://github.com/canonical/marketplace-tribe/issues/2846
