### PR TITLE
fix requested channel not persistent when doc links are clicked

### DIFF
--- a/templates/details/_side-nav.html
+++ b/templates/details/_side-nav.html
@@ -25,7 +25,7 @@
         {% if nav_group.navlink_text %}
           <h3>{{ nav_group.navlink_text }}</h3>
         {% endif %}
-        {{ macros.create_navigation(nav_group.children) }}
+        {{ macros.create_navigation(nav_group.children, channel_requested) }}
       {% endfor %}
     </div>
   </nav>

--- a/templates/partial/_macros.html
+++ b/templates/partial/_macros.html
@@ -1,4 +1,4 @@
-{% macro create_navigation(nav_items) %}
+{% macro create_navigation(nav_items, channel_requested=None) %}
   <ul>
     {% for element in nav_items %}
     <li>


### PR DESCRIPTION
## Done
- fix requested channel not persistent when doc links are clicked
## How to QA
- Click on a charm
- Select a channel 
- Click on a documentation link
## Issue / Card
Fixes #1423 

## Screenshots
<img width="1178" alt="image" src="https://user-images.githubusercontent.com/47438585/202212565-73fbebec-3b3c-4fbd-a4d8-e027aa91ff44.png">
