### PR TITLE
WD-899 add version to WD-899-add-interface-version-to-charmhub-io-interfaces-interface-name-versionresponse

### DIFF
--- a/webapp/interfaces/views.py
+++ b/webapp/interfaces/views.py
@@ -78,6 +78,7 @@ def single_interface(interface, version):
         res = convert_readme(readme)
         res["name"] = get_interface_name_from_readme(readme)
         res["charms"] = get_interface_yml(interface, version)
+        res["version"] = version
         res["other_charms"] = {
             "providers": other_providers,
             "requirers": other_requirers,


### PR DESCRIPTION
## Done
- Add the interface version to the response of WD-899-add-interface-version-to-charmhub-io-interfaces-interface-name-version
## How to QA
- Go to WD-899-add-interface-version-to-charmhub-io-interfaces-interface-name-version
- The response should include `version`
## Issue / Card
Fixes #
https://warthogs.atlassian.net/browse/WD-899
## Screenshots
