### PR TITLE
Interface page QA

### DIFF
--- a/static/js/src/interfaces/components/InterfaceDetails/InterfaceDetails.tsx
+++ b/static/js/src/interfaces/components/InterfaceDetails/InterfaceDetails.tsx
@@ -55,6 +55,12 @@ function InterfaceDetails() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(false);
 
+  const hasDeveloperDocumentation = () => {
+    return (
+      interfaceData?.Usage && interfaceData?.Relation && interfaceData?.Behavior
+    );
+  };
+
   useEffect(() => {
     setLoading(true);
 
@@ -116,14 +122,16 @@ function InterfaceDetails() {
                       Charms
                     </a>
                   </li>
-                  <li className="p-side-navigation__item">
-                    <a
-                      href="#developer-documentation"
-                      className="p-side-navigation__link"
-                    >
-                      Developer documentation
-                    </a>
-                  </li>
+                  {hasDeveloperDocumentation() && (
+                    <li className="p-side-navigation__item">
+                      <a
+                        href="#developer-documentation"
+                        className="p-side-navigation__link"
+                      >
+                        Developer documentation
+                      </a>
+                    </li>
+                  )}
                 </ul>
               </div>
               <h2 className="p-muted-heading">Relevant links</h2>
@@ -174,14 +182,16 @@ function InterfaceDetails() {
                       Charms
                     </a>
                   </li>
-                  <li className="p-side-navigation__item">
-                    <a
-                      href="#developer-documentation"
-                      className="p-side-navigation__link"
-                    >
-                      Developer documentation
-                    </a>
-                  </li>
+                  {hasDeveloperDocumentation() && (
+                    <li className="p-side-navigation__item">
+                      <a
+                        href="#developer-documentation"
+                        className="p-side-navigation__link"
+                      >
+                        Developer documentation
+                      </a>
+                    </li>
+                  )}
                 </ul>
               </div>
 
@@ -190,16 +200,21 @@ function InterfaceDetails() {
               </Strip>
 
               <Strip bordered shallow>
-                <h3 className="p-heading--4">Providing</h3>
+                <h3 className="p-heading--4">
+                  Providing {interfaceData?.name} {interfaceData?.version}
+                </h3>
                 <h4 className="p-muted-heading">Tested charms</h4>
                 <Row className="u-no-padding--left u-no-padding--right">
                   {interfaceData?.charms?.providers.map((provider) => (
                     <Col size={3} key={provider}>
-                      <iframe
-                        height={260}
-                        style={{ width: "100%" }}
-                        src={`/${provider}/embedded?store_design=true`}
-                      />
+                      <div className="p-card--highlighted">
+                        <iframe
+                          className="u-no-margin--bottom"
+                          height={170}
+                          style={{ width: "100%" }}
+                          src={`/${provider}/embedded/interface`}
+                        />
+                      </div>
                     </Col>
                   ))}
                 </Row>
@@ -223,16 +238,21 @@ function InterfaceDetails() {
               </Strip>
 
               <Strip shallow>
-                <h3 className="p-heading--4">Requiring</h3>
+                <h3 className="p-heading--4">
+                  Requiring {interfaceData?.name} {interfaceData?.version}
+                </h3>
                 <h4 className="p-muted-heading">Tested charms</h4>
                 <Row className="u-no-padding--left u-no-padding--right">
                   {interfaceData?.charms?.consumers.map((consumer) => (
                     <Col size={3} key={consumer}>
-                      <iframe
-                        height={260}
-                        style={{ width: "100%" }}
-                        src={`/${consumer}/embedded?store_design=true`}
-                      />
+                      <div className="p-card--highlighted">
+                        <iframe
+                          className="u-no-margin--bottom"
+                          height={170}
+                          style={{ width: "100%" }}
+                          src={`/${consumer}/embedded/interface`}
+                        />
+                      </div>
                     </Col>
                   ))}
                 </Row>
@@ -255,88 +275,95 @@ function InterfaceDetails() {
                 </p>
               </Strip>
 
-              <Strip bordered shallow>
-                <h2 id="developer-documentation">Developer documentation</h2>
-              </Strip>
-
-              <Strip bordered shallow>
-                <h3 className="p-heading--4">Usage</h3>
-                <ReactMarkdown remarkPlugins={[remarkMermaid]}>
-                  {interfaceData?.Usage.join("\n")}
-                </ReactMarkdown>
-              </Strip>
-
-              <Strip bordered shallow>
-                <h3 className="p-heading--4">Relation data</h3>
-                <Row>
-                  <Col size={3}>
-                    <h4 className="p-muted-heading">Provider</h4>
-                  </Col>
-                  <Col size={6}>
+              {hasDeveloperDocumentation() && (
+                <>
+                  <Strip bordered shallow>
+                    <h2 id="developer-documentation">
+                      Developer documentation
+                    </h2>
+                  </Strip>
+                  <Strip bordered shallow>
+                    <h3 className="p-heading--4">Usage</h3>
                     <ReactMarkdown remarkPlugins={[remarkMermaid]}>
-                      {interfaceData?.Relation?.Provider?.Introduction || ""}
+                      {interfaceData?.Usage?.join("\n")}
                     </ReactMarkdown>
-                    <p>Example:</p>
-                    <ReactMarkdown remarkPlugins={[remarkMermaid]}>
-                      {interfaceData?.Relation?.Provider?.Example.join("\n") ||
-                        ""}
-                    </ReactMarkdown>
-                  </Col>
-                </Row>
-                <Row>
-                  <Col size={3}>
-                    <h4 className="p-muted-heading">Requirer</h4>
-                  </Col>
-                  <Col size={6}>
-                    <ReactMarkdown remarkPlugins={[remarkMermaid]}>
-                      {interfaceData?.Relation?.Requirer?.Introduction || ""}
-                    </ReactMarkdown>
-                    <p>Example:</p>
-                    <ReactMarkdown remarkPlugins={[remarkMermaid]}>
-                      {interfaceData?.Relation?.Requirer?.Example.join("\n") ||
-                        ""}
-                    </ReactMarkdown>
-                  </Col>
-                </Row>
-              </Strip>
-
-              <Strip shallow className="u-no-padding--bottom">
-                <h3 className="p-heading--4">Behaviour</h3>
-                <Row>
-                  <Col size={3}>
-                    <h4 className="p-muted-heading">Direction</h4>
-                  </Col>
-                  <Col size={6}>
-                    <ReactMarkdown remarkPlugins={[remarkMermaid]}>
-                      {(interfaceData?.Direction &&
-                        interfaceData?.Direction.join("\n")) ||
-                        ""}
-                    </ReactMarkdown>
-                  </Col>
-                </Row>
-                <Row>
-                  <Col size={3}>
-                    <h4 className="p-muted-heading">Requirements</h4>
-                  </Col>
-                  <Col size={6}>
-                    <p>{interfaceData?.Behavior?.Introduction}</p>
-                    <h5>Provider</h5>
-                    <ReactMarkdown remarkPlugins={[remarkMermaid]}>
-                      {interfaceData?.Behavior?.Provider?.join("\n")}
-                    </ReactMarkdown>
-                    <h5>Requirer</h5>
-                    <ReactMarkdown remarkPlugins={[remarkMermaid]}>
-                      {interfaceData?.Behavior?.Requirer?.join("\n")}
-                    </ReactMarkdown>
-                  </Col>
-                </Row>
-                <Notification severity="information">
-                  <a href="https://github.com/canonical/charm-relation-interfaces">
-                    Help us improve this page
-                  </a>
-                  .
-                </Notification>
-              </Strip>
+                  </Strip>
+                  <Strip bordered shallow>
+                    <h3 className="p-heading--4">Relation data</h3>
+                    <Row>
+                      <Col size={3}>
+                        <h4 className="p-muted-heading">Provider</h4>
+                      </Col>
+                      <Col size={6}>
+                        <ReactMarkdown remarkPlugins={[remarkMermaid]}>
+                          {interfaceData?.Relation?.Provider?.Introduction ||
+                            ""}
+                        </ReactMarkdown>
+                        <p>Example:</p>
+                        <ReactMarkdown remarkPlugins={[remarkMermaid]}>
+                          {interfaceData?.Relation?.Provider?.Example?.join(
+                            "\n"
+                          ) || ""}
+                        </ReactMarkdown>
+                      </Col>
+                    </Row>
+                    <Row>
+                      <Col size={3}>
+                        <h4 className="p-muted-heading">Requirer</h4>
+                      </Col>
+                      <Col size={6}>
+                        <ReactMarkdown remarkPlugins={[remarkMermaid]}>
+                          {interfaceData?.Relation?.Requirer?.Introduction ||
+                            ""}
+                        </ReactMarkdown>
+                        <p>Example:</p>
+                        <ReactMarkdown remarkPlugins={[remarkMermaid]}>
+                          {interfaceData?.Relation?.Requirer?.Example?.join(
+                            "\n"
+                          ) || ""}
+                        </ReactMarkdown>
+                      </Col>
+                    </Row>
+                  </Strip>
+                  <Strip shallow className="u-no-padding--bottom">
+                    <h3 className="p-heading--4">Behaviour</h3>
+                    {interfaceData?.Direction && (
+                      <Row>
+                        <Col size={3}>
+                          <h4 className="p-muted-heading">Direction</h4>
+                        </Col>
+                        <Col size={6}>
+                          <ReactMarkdown remarkPlugins={[remarkMermaid]}>
+                            {interfaceData?.Direction?.join("\n") || ""}
+                          </ReactMarkdown>
+                        </Col>
+                      </Row>
+                    )}
+                    <Row>
+                      <Col size={3}>
+                        <h4 className="p-muted-heading">Requirements</h4>
+                      </Col>
+                      <Col size={6}>
+                        <p>{interfaceData?.Behavior?.Introduction}</p>
+                        <h5>Provider</h5>
+                        <ReactMarkdown remarkPlugins={[remarkMermaid]}>
+                          {interfaceData?.Behavior?.Provider?.join("\n")}
+                        </ReactMarkdown>
+                        <h5>Requirer</h5>
+                        <ReactMarkdown remarkPlugins={[remarkMermaid]}>
+                          {interfaceData?.Behavior?.Requirer?.join("\n")}
+                        </ReactMarkdown>
+                      </Col>
+                    </Row>
+                    <Notification severity="information">
+                      <a href="https://github.com/canonical/charm-relation-interfaces">
+                        Help us improve this page
+                      </a>
+                      .
+                    </Notification>
+                  </Strip>
+                </>
+              )}
             </Col>
           </Row>
         )}

--- a/templates/interface-card-404.html
+++ b/templates/interface-card-404.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% block meta_title %}Charmhub - The Open Operator Collection{% endblock %}</title>
+  <link rel="preconnect" href="https://assets.ubuntu.com">
+  <link rel="stylesheet" type="text/css" media="screen" href="/static/css/styles.css" />
+  <base target="_blank">
+</head>
+<body>
+  <div style="margin-bottom: 0.25rem">
+    <img src="https://assets.ubuntu.com/v1/4de1c56c-404_v1.svg" alt="Not found" loading="lazy" width="24" height="24">
+  </div>
+  <div style="margin-bottom: 0.25rem">
+    {{ entity_name }} not found
+  </div>
+  <div>
+    <em class="u-text-muted">The requested charm or bundle could not be found, sorry.</em>
+  </div>
+</body>
+</html>

--- a/templates/interface-card.html
+++ b/templates/interface-card.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% block meta_title %}Charmhub - The Open Operator Collection{% endblock %}</title>
+  <link rel="preconnect" href="https://assets.ubuntu.com">
+  <link rel="stylesheet" type="text/css" media="screen" href="/static/css/styles.css" />
+  <base target="_blank">
+</head>
+<body>
+  <div style="margin-bottom: 0.25rem">
+    <img src="{% if package.store_front.icons %}{{ package.store_front.icons[0] }}{% else %}https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_24,h_24/https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg{% endif %}" alt="{{ package.name }}" loading="lazy" width="24" height="24">
+  </div>
+  <div style="margin-bottom: 0.25rem" class="u-truncate" title="{{ package.store_front['display-name'] }}">
+    <a href="/{{ package.name }}">{{ package.store_front["display-name"] }}</a>
+  </div>
+  <div class="u-truncate" style="margin-bottom: 0.25rem" title="{{ package.store_front.publisher_name }}">
+    <em class="u-text-muted">{{ package.store_front.publisher_name }}</em>
+    &nbsp;
+    {% if "kubernetes" in package.store_front["deployable-on"] %}
+      <img alt="Kubernetes" src="https://assets.ubuntu.com/v1/f1852c07-Kubernetes.svg" width="16" height="16">
+    {% endif %}
+    {% if "windows" in package.store_front["deployable-on"] %}
+      <img alt="Windows" src="https://assets.ubuntu.com/v1/ff17c4fe-Windows.svg" width="16" height="16">
+    {% endif %}
+    {% if "vm" in package.store_front["deployable-on"] %}
+      <img alt="VM" src="https://assets.ubuntu.com/v1/a911ecf6-vm-badge.svg" width="16" height="16">
+    {% endif %}
+  </div>
+  <div class="u-text-muted" style="margin-bottom: 1rem">
+    {{ package["default-release"].channel.track }}/{{ package["default-release"].channel.name }}
+  </div>
+  {% if libraries %}
+    <div class="u-align--right">
+      <hr style="margin-bottom: 0.75rem" />
+      <div>
+        <a href="/{{ package.name }}/libraries">See libraries</a>
+      </div>
+    </div>
+  {% endif %}
+</body>
+</html>

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -772,6 +772,44 @@ def entity_embedded_card(entity_name):
         )
 
 
+@store.route(
+    '/<regex("' + DETAILS_VIEW_REGEX + '"):entity_name>/embedded/interface'
+)
+@exclude_xframe_options_header
+def entity_embedded_interface_card(entity_name):
+    channel_request = request.args.get("channel", default=None, type=str)
+    try:
+        package = get_package(entity_name, channel_request, FIELDS)
+
+        package["default-release"]["channel"][
+            "released-at"
+        ] = logic.convert_date(
+            package["default-release"]["channel"]["released-at"]
+        )
+
+        libraries = logic.process_libraries(
+            publisher_api.get_charm_libraries(entity_name)
+        )
+
+        context = {
+            "package": package,
+            "libraries": libraries,
+        }
+
+        return render_template(
+            "interface-card.html",
+            **context,
+        )
+    except Exception:
+        return (
+            render_template(
+                "interface-card-404.html",
+                entity_name=entity_name,
+            ),
+            404,
+        )
+
+
 @store.route('/<regex("' + DETAILS_VIEW_REGEX + '"):entity_name>/icon')
 def entity_icon(entity_name):
     icon_url = (


### PR DESCRIPTION
## Done
Addressed the following QA feedback:
- Overview section is missing **[There is no overview to display currently]**
- This [interface page](https://charmhub.io/interfaces/prometheus_scrape-v0) appears empty **[Fixed]**
- Tested charms heading should have a tooltip as per [design](https://zpl.io/RMLKGBg). **[Currently no content - [issue raised](https://warthogs.atlassian.net/browse/WD-932)]**
- Cards don’t look the same as the final design, and the content it’s not what we [designed](https://zpl.io/RMLKGBg) **[Fixed]**
- ‘How to test a charm’ is missing the external link icon **[As discussed we don't use this pattern anymore]**
- On this [interface](https://charmhub.io/interfaces/tls_certificates-v0) the Direction section is empty, so should be hidden **[Fixed]**

## How to QA
- Go to https://charmhub-io-1452.demos.haus/interfaces
- Go to some interface pages and check that the above feedback has been addressed

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-938
