### PR TITLE
Apply the expandable navigation to the topics pages

### DIFF
--- a/static/js/src/base/docs-side-nav.js
+++ b/static/js/src/base/docs-side-nav.js
@@ -1,0 +1,160 @@
+(function () {
+  /**
+  Toggles the expanded/collapsed classed on side navigation element.
+
+  @param {HTMLElement} sideNavigation The side navigation element.
+  @param {Boolean} show Whether to show or hide the drawer.
+*/
+  function toggleDrawer(sideNavigation, show) {
+    const toggleButtonOutsideDrawer = sideNavigation.querySelector(
+      ".p-side-navigation__toggle"
+    );
+    const toggleButtonInsideDrawer = sideNavigation.querySelector(
+      ".p-side-navigation__toggle--in-drawer"
+    );
+
+    if (sideNavigation) {
+      if (show) {
+        sideNavigation.classList.remove("is-drawer-collapsed");
+        sideNavigation.classList.add("is-drawer-expanded");
+
+        toggleButtonInsideDrawer.focus();
+        toggleButtonOutsideDrawer.setAttribute("aria-expanded", true);
+        toggleButtonInsideDrawer.setAttribute("aria-expanded", true);
+      } else {
+        sideNavigation.classList.remove("is-drawer-expanded");
+        sideNavigation.classList.add("is-drawer-collapsed");
+
+        toggleButtonOutsideDrawer.focus();
+        toggleButtonOutsideDrawer.setAttribute("aria-expanded", false);
+        toggleButtonInsideDrawer.setAttribute("aria-expanded", false);
+      }
+    }
+  }
+
+  // throttle util (for window resize event)
+  var throttle = function (fn, delay) {
+    var timer = null;
+    return function () {
+      var context = this,
+        args = arguments;
+      clearTimeout(timer);
+      timer = setTimeout(function () {
+        fn.apply(context, args);
+      }, delay);
+    };
+  };
+
+  /**
+    Attaches event listeners for the side navigation toggles
+    @param {HTMLElement} sideNavigation The side navigation element.
+  */
+  function setupSideNavigation(sideNavigation) {
+    var toggles = [].slice.call(
+      sideNavigation.querySelectorAll(".js-drawer-toggle")
+    );
+    var drawerEl = sideNavigation.querySelector(".p-side-navigation__drawer");
+
+    // hide navigation drawer on small screens
+    sideNavigation.classList.add("is-drawer-hidden");
+
+    // setup drawer element
+    drawerEl.addEventListener("animationend", () => {
+      if (!sideNavigation.classList.contains("is-drawer-expanded")) {
+        sideNavigation.classList.add("is-drawer-hidden");
+      }
+    });
+
+    window.addEventListener("keydown", (e) => {
+      if (e.key === "Escape") {
+        toggleDrawer(sideNavigation, false);
+      }
+    });
+
+    // setup toggle buttons
+    toggles.forEach(function (toggle) {
+      toggle.addEventListener("click", function (event) {
+        event.preventDefault();
+
+        if (sideNavigation) {
+          sideNavigation.classList.remove("is-drawer-hidden");
+          toggleDrawer(
+            sideNavigation,
+            !sideNavigation.classList.contains("is-drawer-expanded")
+          );
+        }
+      });
+    });
+
+    // hide side navigation drawer when screen is resized
+    window.addEventListener(
+      "resize",
+      throttle(function () {
+        toggles.forEach((toggle) => {
+          return toggle.setAttribute("aria-expanded", false);
+        });
+        // remove expanded/collapsed class names to avoid unexpected animations
+        sideNavigation.classList.remove("is-drawer-expanded");
+        sideNavigation.classList.remove("is-drawer-collapsed");
+        sideNavigation.classList.add("is-drawer-hidden");
+      }, 10)
+    );
+  }
+
+  /**
+    Attaches event listeners for all the side navigations in the document.
+    @param {String} sideNavigationSelector The CSS selector matching side navigation elements.
+  */
+  function setupSideNavigations(sideNavigationSelector) {
+    // Setup all side navigations on the page.
+    var sideNavigations = [].slice.call(
+      document.querySelectorAll(sideNavigationSelector)
+    );
+
+    sideNavigations.forEach(setupSideNavigation);
+  }
+
+  setupSideNavigations('.p-side-navigation, [class*="p-side-navigation--"]');
+
+  // Setup expandable side navigation
+
+  var expandToggles = document.querySelectorAll(".p-side-navigation__expand");
+  var navigationLinks = document.querySelectorAll(".p-side-navigation__link");
+
+  // setup default values of aria-expanded for the toggle button, list title and list itself
+  const setup = (toggle) => {
+    const isExpanded = toggle.getAttribute("aria-expanded") === "true";
+    if (!isExpanded) {
+      toggle.setAttribute("aria-expanded", isExpanded);
+    }
+    const item = toggle.closest(".p-side-navigation__item");
+    const link = item.querySelector(".p-side-navigation__link");
+    const nestedList = item.querySelector(".p-side-navigation__list");
+    if (!link?.hasAttribute("aria-expanded")) {
+      link.setAttribute("aria-expanded", isExpanded);
+    }
+    if (!nestedList?.hasAttribute("aria-expanded")) {
+      nestedList.setAttribute("aria-expanded", isExpanded);
+    }
+  };
+
+  const handleToggle = (e) => {
+    const item = e.currentTarget.closest(".p-side-navigation__item");
+    const button = item.querySelector(".p-side-navigation__expand");
+    const link = item.querySelector(".p-side-navigation__link");
+    const nestedList = item.querySelector(".p-side-navigation__list");
+    [button, link, nestedList].forEach((el) =>
+      el.setAttribute(
+        "aria-expanded",
+        el.getAttribute("aria-expanded") === "true" ? "false" : "true"
+      )
+    );
+  };
+
+  expandToggles.forEach((toggle) => {
+    setup(toggle);
+    toggle.addEventListener("click", (e) => {
+      handleToggle(e);
+    });
+  });
+})();

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -44,6 +44,7 @@ $color-text-orange: #d54110;
 @include vf-p-search-box;
 @include vf-p-strip;
 @include vf-p-side-navigation;
+@include vf-p-side-navigation-expandable;
 @include vf-p-table-of-contents;
 @include vf-p-table-mobile-card;
 @include vf-p-tabs;

--- a/templates/topics/document.html
+++ b/templates/topics/document.html
@@ -3,20 +3,34 @@
 {% block title %}{% if document %}{{ document.title }}{% else %}Topic page{% endif %}{% endblock %}
 {% block meta_description %}{{ document.body_html | striptags | truncate(155) }}{% endblock %}
 
-{% macro create_navigation(nav_items) %}
-  <ul>
+{% macro create_navigation(nav_items, expandable=False, expanded=False) %}
+  <ul class="p-side-navigation__list">
     {% for element in nav_items %}
-    <li>
+    <li class="p-side-navigation__item">
       {% if element.navlink_href %}
-        <a href="{{ element.navlink_href }}"
-          {% if request.path == element.navlink_href %}aria-current="page"{% endif %}
-        >{{ element.navlink_text }}</a>
+      <a
+        class="p-side-navigation__link {% if expandable and element.children %}is-expandable{% endif %}"
+        href="{{ element.navlink_href }}"
+        {% if expandable and element.children %}aria-expanded={% if expanded %}"true"{% else %}"false"{% endif %}{% endif %}
+        {% if element.is_active %}aria-current="page"{% endif %}
+      >{{ element.navlink_text }}</a>
       {% else %}
-        <strong>{{ element.navlink_text }}</strong>
+        <strong
+          class="p-side-navigation__text {% if expandable and element.children %}is-expandable{% endif %}"
+          {% if expandable and element.children %}aria-expanded={% if expanded %}"true"{% else %}"false"{% endif %}{% endif %}
+          {% if element.is_active %}aria-current="page"{% endif %}
+        >{{ element.navlink_text }}</strong>
       {% endif %}
 
-      {% if element.children %}
-        {{ create_navigation(element.children) }}
+      {% if expandable %}
+        {% if element.children %}
+            <button class="p-side-navigation__expand" aria-expanded={% if element.is_active or element.has_active_child %}"true"{% else %}"false"{% endif %} aria-label="show submenu for {{ element.navlink_text }}"></button>
+        {% endif %}
+        {{ create_navigation(element.children, expandable, element.is_active or element.has_active_child) }}
+      {% else %}
+        {% if element.children %}
+          {{ create_navigation(element.children, expandable) }}
+        {% endif %}
       {% endif %}
     </li>
     {% endfor %}
@@ -37,7 +51,7 @@
       <select>
       {% endif %}
 
-      <nav data-js="navigation" class="p-side-navigation--raw-html" id="{{ navigation['path'] or 'default' }}">
+      <nav data-js="navigation" class="p-side-navigation" id="{{ navigation['path'] or 'default' }}">
         <a href="#{{ navigation['path'] or 'default' }}" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="{{ navigation['path'] or 'default' }}">
           Toggle side navigation
         </a>
@@ -49,19 +63,25 @@
             </a>
           </div>
           {% for nav_group in navigation.nav_items %}
-            {% if nav_group.navlink_href %}
-              <h3>
-                <a
-                  class="p-link--soft"
-                  href="{{ nav_group.navlink_href }}"
-                  {% if request.path == nav_group.navlink_href %}aria-current="page"{% endif %}
-                >{{ nav_group.navlink_text }}</a>
-            </h3>
-            {% elif nav_group.navlink_text %}
-               <h3>{{ nav_group.navlink_text }}</h3>
+          {% if not nav_group.hidden %}
+            {% if nav_group.navlink_text %}
+              {% if nav_group.navlink_href %}
+              <h3 class="p-side-navigation__heading--linked">
+                <a class="p-side-navigation__link" href="{{ nav_group.navlink_href }}" {% if nav_group.is_active %}aria-current="page"{% endif %}>
+                  {{ nav_group.navlink_text }}
+                </a>
+              </h3>
+              {% else %}
+                <h3 class="p-side-navigation__heading">{{ nav_group.navlink_text }}</h3>
+              {% endif %}
             {% endif %}
-            {{ create_navigation(nav_group.children) }}
-          {% endfor %}
+            {#
+              Use `create_navigation(nav_group.children)` for a default, fully expanded navigation.
+              Use `create_navigation(nav_group.children, expandable=True)` for the nested nav levels to expand only when parent page is active.
+            #}
+            {{ create_navigation(nav_group.children, expandable=True) }}
+          {% endif %}
+        {% endfor %}
         </div>
         <a href="https://juju.is/tutorials/how-to-write-a-topic-page" class="p-button--positive p-topics-contribute__button">How to contribute a Topic</a>
       </nav>
@@ -81,4 +101,6 @@
     </main>
   </div>
 </section>
+
+<script src="{{ versioned_static('js/dist/docs-side-nav.js') }}"></script>
 {% endblock %}

--- a/webpack.config.entry.js
+++ b/webpack.config.entry.js
@@ -1,6 +1,7 @@
 module.exports = {
   about: "./static/js/src/public/about/index.js",
   docs: "./static/js/src/public/docs/index.js",
+  "docs-side-nav": "./static/js/src/base/docs-side-nav.js",
   base: "./static/js/src/base/base.js",
   details: "./static/js/src/public/details/index.js",
   details_overview: "./static/js/src/public/details/overview/index.js",


### PR DESCRIPTION
## Done
- Included the expandable navigation Vanilla component
- Copy the JS from juju.is and include it in the entries
- Updated the macro in the document
- Updated the navigation index numbers in the source discourse topics

## How to QA
1. Open the demo
2. Go to /topics
3. Go to each topic and check the navigation works as expected

## Issue / Card
Fixes https://github.com/canonical/charmhub.io/issues/1418

## Screenshots
| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1413534/206849399-ba93264e-ebab-48a1-81ae-74dfb45f712d.png) | ![image](https://user-images.githubusercontent.com/1413534/206849356-781eea8d-00fe-4545-88c1-450c3b026563.png) |
