### PR TITLE
Update link in navigation

### DIFF
--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -41,7 +41,7 @@
               <a class="p-navigation__dropdown-item" href="https://juju.is/tutorials">Tutorials</a>
             </li>
             <li>
-              <a class="p-navigation__dropdown-item" href="https://juju.is/cloud-native-kubernetes-usage-report-2022">Native Operations Report</a>
+              <a class="p-navigation__dropdown-item" href="https://juju.is/cloud-native-kubernetes-usage-report-2022">Kubernetes and cloud native operations report 2022</a>
             </li>
             <li>
               <a class="p-navigation__dropdown-item" href="https://juju.is/operator-day">Operator Day</a>


### PR DESCRIPTION
## Done
Updated the link text for the k8s report link in the navigation

## How to QA
- Go to https://charmhub-io-1460.demos.haus/
- Check that under the "Learn" menu there is a link with the text "Kubernetes and cloud native operations report 2022"
