### PR TITLE
Update the current dropdown under the main navigation in Charmhub/Juju

### DIFF
--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -30,18 +30,31 @@
             <li>
               <div class="p-navigation__dropdown-item is-title">
                 <div class="p-muted-heading u-no-margin--bottom">
-                  Documentation and resources
+                  Documentation
                 </div>
               </div>
             </li>
             <li>
-              <a class="p-navigation__dropdown-item" href="https://juju.is/docs">Documentation</a>
+              <a class="p-navigation__dropdown-item" href="https://juju.is/docs/olm">OLM docs: Manage charms</a>
+            </li>
+            <li>
+              <a class="p-navigation__dropdown-item" href="https://juju.is/docs/sdk">SDK docs: Build charms</a>
+            </li>
+            <li>
+              <a class="p-navigation__dropdown-item" href="https://juju.is/docs/dev">Dev docs: Contribute to the OLM</a>
             </li>
             <li>
               <a class="p-navigation__dropdown-item" href="https://juju.is/tutorials">Tutorials</a>
             </li>
             <li>
-              <a class="p-navigation__dropdown-item" href="https://juju.is/cloud-native-kubernetes-usage-report-2022">Kubernetes and cloud native operations report 2022</a>
+              <div class="p-navigation__dropdown-item is-title">
+                <div class="p-muted-heading u-no-margin--bottom">
+                  Resources
+                </div>
+              </div>
+            </li>
+            <li>
+              <a class="p-navigation__dropdown-item" href="https://juju.is/cloud-native-kubernetes-usage-report-2022">Kubernetes & Cloud Native Operations Report</a>
             </li>
             <li>
               <a class="p-navigation__dropdown-item" href="https://juju.is/operator-day">Operator Day</a>
@@ -90,10 +103,10 @@
               <a class="p-navigation__dropdown-item" href="https://juju.is/careers">Careers</a>
             </li>
           </ul>
-        </li>     
+        </li>
         <li class="p-navigation__item">
           <a class="p-navigation__link" href="https://jaas.ai">JAAS</a>
-        </li>   
+        </li>
       </ul>
       <ul class="p-navigation__items global-nav">
         <li class="p-navigation__item">


### PR DESCRIPTION
## Done
Updated the current dropdown under the main navigation in Charmhub/Juju 

## How to QA
Go to https://charmhub-io-1471.demos.haus/
Check if the current "Learn" navigation has DOCUMENTATION and LEARN dropdown item titles
Check if each dropdown item has correct href

## Issue / Card
Fixes #https://warthogs.atlassian.net/browse/WD-1238

## Screenshots
<img width="1106" alt="Charmhub subnavigation" src="https://user-images.githubusercontent.com/90341644/214580744-9467ed81-1f66-42b9-a914-059a1d164bbb.png">
