### PR TITLE
Fix library download link

### DIFF
--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -504,10 +504,8 @@ def download_library(entity_name, library_name):
     lib_parts = library_name.split(".")
 
     if len(lib_parts) > 2:
-        group_name = ".".join(lib_parts[:-2])
         lib_name = "." + ".".join(lib_parts[-2:])
     else:
-        group_name = "others"
         lib_name = library_name
 
     libraries = logic.process_libraries(
@@ -517,7 +515,7 @@ def download_library(entity_name, library_name):
     library = next(
         (
             lib
-            for lib in libraries.get(group_name, {})
+            for lib in libraries
             if lib.get("name") == lib_name
         ),
         None,

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -513,11 +513,7 @@ def download_library(entity_name, library_name):
     )
 
     library = next(
-        (
-            lib
-            for lib in libraries
-            if lib.get("name") == lib_name
-        ),
+        (lib for lib in libraries if lib.get("name") == lib_name),
         None,
     )
 


### PR DESCRIPTION
## Done
- Fix Library download link not working
## How to QA
- Go to any charm
- Click on `Libraries`
- Click the download link and ensure it downloads the charm library
- Example: https://charmhub-io-1478.demos.haus/alertmanager-k8s/libraries/alertmanager_dispatch
## Issue / Card https://warthogs.atlassian.net/browse/WD-1808
Fixes #

## Screenshots
