### PR TITLE
Update sitemaps to remove juju redirects

### DIFF
--- a/templates/sitemap/sitemap.xml
+++ b/templates/sitemap/sitemap.xml
@@ -6,7 +6,4 @@
   <sitemap>
     <loc>{{ base_url }}/sitemap-operators.xml</loc>
   </sitemap>
-  <sitemap>
-    <loc>{{ base_url }}/tutorials/sitemap.xml</loc>
-  </sitemap>
 </sitemapindex>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -116,12 +116,6 @@ def site_map():
 @app.route("/sitemap-links.xml")
 def site_map_links():
     links = [
-        "/overview",
-        "/about",
-        "/manifesto",
-        "/publishing",
-        "/governance",
-        "/glossary",
         "/contact-us",
     ]
 


### PR DESCRIPTION
## Done
- Remove links that redirect to other sites

## How to QA
- Visit the https://charmhub-io-1483.demos.haus/sitemap.xml
- Visit linked to .xml files
- Ensure juju.is isn't mentioned anywhere / the link doesn't redirect to a juju sitemap.

## Issue / Card
Fixes #

## Screenshots
