### PR TITLE
fix wrong hostname in /configure WD-1814

### DIFF
--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -481,3 +481,15 @@ def format_slug(slug):
         .replace("And", "and")
         .replace("Iot", "IoT")
     )
+
+def parse_readme(readme, channel_request=None):
+    readme = html(readme)
+    readme = re.sub("(<!--.*-->)", "", readme, flags=re.DOTALL)
+    readme = readme.replace("https://charmhub.io/", "/")
+    if channel_request:
+        readme = readme.replace("/configure", "/configure/?channel={}".format(channel_request))
+
+    readme = get_soup(readme)
+    readme = modify_headers(readme)
+
+    return readme

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -482,12 +482,15 @@ def format_slug(slug):
         .replace("Iot", "IoT")
     )
 
+
 def parse_readme(readme, channel_request=None):
     readme = html(readme)
     readme = re.sub("(<!--.*-->)", "", readme, flags=re.DOTALL)
     readme = readme.replace("https://charmhub.io/", "/")
     if channel_request:
-        readme = readme.replace("/configure", "/configure/?channel={}".format(channel_request))
+        readme = readme.replace(
+            "/configure", "/configure/?channel={}".format(channel_request)
+        )
 
     readme = get_soup(readme)
     readme = modify_headers(readme)

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -13,7 +13,6 @@ from flask import Blueprint, Response, abort
 from flask import current_app as app
 from flask import jsonify, redirect, render_template, request
 from pybadges import badge
-from mistune import html
 
 from webapp.config import DETAILS_VIEW_REGEX, CATEGORIES
 from webapp.decorators import (
@@ -239,14 +238,8 @@ def details_overview(entity_name):
     readme = package["default-release"]["revision"].get(
         "readme-md", "No readme available"
     )
-
-    readme = html(readme)
-    # Remove Markdown/HTML comments
-    readme = re.sub("(<!--.*-->)", "", readme, flags=re.DOTALL)
-    readme = readme.replace("https://charmhub.io/", "/")
-    readme = get_soup(readme)
-    readme = modify_headers(readme)
-
+    readme = logic.parse_readme(readme, channel_request)
+   
     context["readme"] = readme
     context["package_type"] = package["type"]
 

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -1,5 +1,3 @@
-import re
-
 import humanize
 import talisker
 from canonicalwebteam.discourse import DocParser
@@ -19,7 +17,7 @@ from webapp.decorators import (
     redirect_uppercase_to_lowercase,
     store_maintenance,
 )
-from webapp.helpers import get_soup, modify_headers, discourse_api
+from webapp.helpers import discourse_api
 from webapp.store import logic
 from webapp.topics.views import topic_list
 
@@ -239,7 +237,7 @@ def details_overview(entity_name):
         "readme-md", "No readme available"
     )
     readme = logic.parse_readme(readme, channel_request)
-   
+
     context["readme"] = readme
     context["package_type"] = package["type"]
 

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -243,6 +243,7 @@ def details_overview(entity_name):
     readme = html(readme)
     # Remove Markdown/HTML comments
     readme = re.sub("(<!--.*-->)", "", readme, flags=re.DOTALL)
+    readme = readme.replace("https://charmhub.io/", "/")
     readme = get_soup(readme)
     readme = modify_headers(readme)
 


### PR DESCRIPTION
## Done
- fix wrong hostname in /configure
## How to QA
- Go to https://charmhub-io-1492.demos.haus/mongodb look through the documentation for "review the options" click and confirm that the url hostname is the current environment for example: localhost:8045/mongodb/configure, https://charmhub-io-1492.demos.haus/mongodb/configure, https://staging.charmhub.io/mongodb/configure
## Issue / Card WD-1814, WD-1813, WD-1815
Fixes #

## Screenshots
