### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ For more detailed local development instructions, see [HACKING.md](HACKING.md).
 
 ## License
 
-The content of this project is licensed under the [Creative Commons Attribution-ShareAlike 4.0 International license](https://creativecommons.org/licenses/by-sa/4.0/), and the underlying code used to format and display that content is licensed under the [LGPLv3](http://opensource.org/licenses/lgpl-3.0.html) by [Canonical Ltd](http://www.canonical.com/).
+The content of this project is licensed under the [Creative Commons Attribution-ShareAlike 4.0 International license](https://creativecommons.org/licenses/by-sa/4.0/), and the underlying code used to format and display that content is licensed under the [LGPLv3](http://opensource.org/licenses/lgpl-3.0) by [Canonical Ltd](http://www.canonical.com/).
 
 
 With ♥ from Canonical


### PR DESCRIPTION
## Done
Fixed broken license link in README

## QA
Check that the updated link in the README works

## Issue
Fixes https://github.com/canonical/snapcraft.io/issues/4198