### PR TITLE
Fix charm track channel information

### DIFF
--- a/templates/details/_details-header.html
+++ b/templates/details/_details-header.html
@@ -98,7 +98,7 @@
                     {% endif %}
                   </div>
                   <div>
-                    {% for channel in base["bases"] %}
+                    {% for channel in channel_data.latest.bases %}
                       <span class="series-tag">
                         {{ channel.replace("Ubuntu ", "") }}
                       </span>

--- a/templates/partial/_channel-map.html
+++ b/templates/partial/_channel-map.html
@@ -48,7 +48,7 @@
                   <div class="series-tags u-no-margin--top">
                     {% for channel_base in package.store_front.all_channel_bases %}
                     {% if channel_base.channel == channel %}
-                    {% for base in channel_base.bases %}
+                    {% for base in channel_data.latest.bases %}
                       <span class="series-tag">{{ base }}</span>
                       {% endfor %}
                     {% endif %}


### PR DESCRIPTION
## Done
Fixed the incorrect platforms being displayed for each channel

## QA
- Go to https://charmhub-io-1503.demos.haus/keystone?channel=zed/stable
- Check that the only platforms are 22.10 and 22.04
- Open the channel selector
- Check that the platforms in the "Runs on" column for each channel match the selected channel

## Issue / Card
Fixes #1481
Fixes #1491
