### PR TITLE
Update docs link to go to new SDK documentation

### DIFF
--- a/templates/details/_side-nav.html
+++ b/templates/details/_side-nav.html
@@ -101,7 +101,7 @@
   <hr class="p-separator--shallow" />
 {% endif %}
 {% if not navigation %}
-  <a class="p-button--positive u-no-margin--bottom" href="https://charmhub.io/tutorials/add-docs-to-your-charmhub-page">Add docs to a charm</a>
+  <a class="p-button--positive u-no-margin--bottom" href="https://juju.is/docs/sdk/add-docs-to-your-charmhub-page">Add docs to a charm</a>
   <hr class="p-separator--shallow" />
 {% endif %}
 <h4 class="p-heading--5 u-no-margin--bottom">Discuss this {{ package.type }}</h4>

--- a/templates/details/empty-docs.html
+++ b/templates/details/empty-docs.html
@@ -11,7 +11,7 @@
       <div class="col-9 charm-empty-docs-content">
         <h4>Docs help you learn how to use a charm</h4>
         <p>Looks like {{ package.store_front.publisher_name }} hasn’t added any docs to this charm yet.</p>
-        <p class="u-no-margin--bottom"><a class="p-button--positive u-no-margin--bottom" href="https://charmhub.io/tutorials/add-docs-to-your-charmhub-page">Learn how to add docs to a charm</a></p>
+        <p class="u-no-margin--bottom"><a class="p-button--positive u-no-margin--bottom" href="https://juju.is/docs/sdk/add-docs-to-your-charmhub-page">Learn how to add docs to a charm</a></p>
       </div>
     </div>
   </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1220,7 +1220,7 @@
   resolved "https://registry.yarnpkg.com/@canonical/latest-news/-/latest-news-1.4.1.tgz#dcdd445ac2268a54cf60f2f8c725b6bdeb285d71"
   integrity sha512-lwrikCj0Y11X8Ln8D+elp6Ri3mYjMjsAOJtadNEFzhBrgmg8TVGYJjOdwy8TvRaxy7fHnvVajIKAYWX44Tfj6w==
 
-"@canonical/react-components@^0.38.0":
+"@canonical/react-components@0.38.0":
   version "0.38.0"
   resolved "https://registry.yarnpkg.com/@canonical/react-components/-/react-components-0.38.0.tgz#180eb0412d62e29002a724386d08d5bea959b58b"
   integrity sha512-0t20yrHamxCPCxlJu7ZjXMFexrfZXUSTZvVL+dSoTF8ZHTTi/NUnvgLMak8NWzVht9nOkVb6ltAA8pPSmMr8rg==


### PR DESCRIPTION
## Done
- Update link for "Add docs to a charm" to point to the SDK Docs instead of tutorials

## How to QA
- Visit the demo https://charmhub-io-1504.demos.haus/elasticsearch-k8s
- Click the Add docs to a charm. You should be redirects to a documentation page, instead of the tutorial.

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/JUJU-2792

## Screenshots
