### PR TITLE
rename Tested Charms to Featured Charms on a Charmhub interface page

### DIFF
--- a/static/js/src/interfaces/components/InterfaceDetails/InterfaceDetails.tsx
+++ b/static/js/src/interfaces/components/InterfaceDetails/InterfaceDetails.tsx
@@ -241,7 +241,7 @@ function InterfaceDetails() {
                 <h3 className="p-heading--4">
                   Requiring {interfaceData?.name} {interfaceData?.version}
                 </h3>
-                <h4 className="p-muted-heading">Tested charms</h4>
+                <h4 className="p-muted-heading">Featured charms</h4>
                 <Row className="u-no-padding--left u-no-padding--right">
                   {interfaceData?.charms?.consumers.map((consumer) => (
                     <Col size={3} key={consumer}>

--- a/static/js/src/interfaces/components/InterfaceDetails/InterfaceDetails.tsx
+++ b/static/js/src/interfaces/components/InterfaceDetails/InterfaceDetails.tsx
@@ -203,7 +203,7 @@ function InterfaceDetails() {
                 <h3 className="p-heading--4">
                   Providing {interfaceData?.name} {interfaceData?.version}
                 </h3>
-                <h4 className="p-muted-heading">Tested charms</h4>
+                <h4 className="p-muted-heading">Featured charms</h4>
                 <Row className="u-no-padding--left u-no-padding--right">
                   {interfaceData?.charms?.providers.map((provider) => (
                     <Col size={3} key={provider}>


### PR DESCRIPTION
## Done
Renamed "Tested Charms" to "Featured Charms" on a Charmhub interface page

## How to QA
Go to https://charmhub-io-1508.demos.haus/interfaces/mysql_client-v0
See if there is "Featured Charms" as a heading for a card.

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-2143

## Screenshots
<img width="1133" alt="Screen Shot 2023-02-21 at 4 11 12 PM" src="https://user-images.githubusercontent.com/90341644/220399098-55980fd1-27b9-4d19-b747-2c9ef653358c.png">
