### PR TITLE
Remove version from interfaces index url

### DIFF
--- a/static/js/src/interfaces/components/InterfacesIndex/InterfacesIndex.tsx
+++ b/static/js/src/interfaces/components/InterfacesIndex/InterfacesIndex.tsx
@@ -185,9 +185,7 @@ function InterfacesIndex() {
                           justifyContent: "space-between",
                         }}
                       >
-                        <Link
-                          to={`/interfaces/${item?.name}-v${item?.version}`}
-                        >
+                        <Link to={`/interfaces/${item?.name}`}>
                           {item?.name}
                         </Link>
                         {item?.status !== "Live" && (


### PR DESCRIPTION
## Done
Removed the version from interface URLs on the index page

## How to QA
- Go to https://charmhub-io-1519.demos.haus/interfaces
- Click on any of the interfaces
- The page should load and show the interface details