### PR TITLE
WD-2146 add a related link to specification archive (ver.2)

### DIFF
--- a/static/js/src/interfaces/components/InterfaceDetails/InterfaceDetails.tsx
+++ b/static/js/src/interfaces/components/InterfaceDetails/InterfaceDetails.tsx
@@ -217,6 +217,9 @@ function InterfaceDetails() {
                   &nbsp;&nbsp;Submit a bug
                 </a>
               </p>
+              <p>
+                <a href={`https://github.com/canonical/charm-relation-interfaces/tree/main/interfaces/${interfaceName}${interfaceData?.version ? `/${interfaceData.version}` : ""}`}>Specification folder</a>
+              </p>
               {!isCommunity && (
                 <>
                   <h2 className="p-muted-heading">Help us improve this page</h2>
@@ -303,7 +306,7 @@ function InterfaceDetails() {
               ) && (
                 <Strip bordered shallow>
                   <h3 className="p-heading--4">
-                    Providing {interfaceData?.name} {interfaceData?.version}
+                    Providing {interfaceData?.name}
                   </h3>
                   {!!interfaceData?.charms?.providers?.length && (
                     <>
@@ -357,7 +360,7 @@ function InterfaceDetails() {
               ) && (
                 <Strip shallow>
                   <h3 className="p-heading--4">
-                    Requiring {interfaceData?.name} {interfaceData?.version}
+                    Requiring {interfaceData?.name}
                   </h3>
                   {!!interfaceData?.charms?.consumers?.length && (
                     <>

--- a/static/js/src/interfaces/components/InterfaceDetails/InterfaceDetails.tsx
+++ b/static/js/src/interfaces/components/InterfaceDetails/InterfaceDetails.tsx
@@ -217,9 +217,14 @@ function InterfaceDetails() {
                   &nbsp;&nbsp;Submit a bug
                 </a>
               </p>
+              {!isCommunity && (
               <p>
-                <a href={`https://github.com/canonical/charm-relation-interfaces/tree/main/interfaces/${interfaceName}${interfaceData?.version ? `/${interfaceData.version}` : ""}`}>Specification folder</a>
+                <a href={`https://github.com/canonical/charm-relation-interfaces/tree/main/interfaces/${interfaceName}${interfaceData?.version ? `/${interfaceData.version}` : ""}`}>
+                  <Icon name="containers" />
+                  &nbsp;&nbsp;Specification folder
+                </a>
               </p>
+              )}
               {!isCommunity && (
                 <>
                   <h2 className="p-muted-heading">Help us improve this page</h2>

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -51,6 +51,7 @@ $breakpoint-navigation-threshold: 1110px;
 @include vf-l-fluid-breakout;
 @include vf-p-icon-change-version;
 @include vf-p-icon-submit-bug;
+@include vf-p-icon-containers;
 
 // Vanilla utilities
 @include vf-u-align;


### PR DESCRIPTION
## Done
 added a related link and icon to a "Specification folder"

## How to QA
Go to https://charmhub-io-1523.demos.haus/interfaces/ingress_per_unit
See if there is an icon and a "Specification folder" which links to the correct GH url

## Issue / Card
Fixes #https://warthogs.atlassian.net/browse/WD-2146

## Screenshots
<img width="298" alt="Screen Shot 2023-02-24 at 9 09 13 AM" src="https://user-images.githubusercontent.com/90341644/221138362-e8644c28-b289-400d-90ea-9da4c2f0c7ae.png">
