### PR TITLE
Remove FINOS from topic pages.

### DIFF
--- a/webapp/topics/topics.json
+++ b/webapp/topics/topics.json
@@ -14,13 +14,6 @@
         "categories": ["featured", "ai-ml", "big-data", "containers", "networking"]
     },
     {
-        "name": "FINOS Charmed Operators",
-        "slug": "finos",
-        "topic_id": 5832,
-        "description": "Juju and Charms are the easiest way to quickly try FINOS projects in your laptop. Here you can also find information about enterprise-grade deployment options that covers day-2 operations.",
-        "categories": ["featured", "cloud", "big-data"]
-    },
-    {
         "name": "Operator’s Corner",
         "slug": "operators-corner",
         "topic_id": 5990,

--- a/webapp/topics/topics.json
+++ b/webapp/topics/topics.json
@@ -18,6 +18,6 @@
         "slug": "operators-corner",
         "topic_id": 5990,
         "description": "Welcome to the Operator’s Corner, where you can find information about the best practices on developing your Charmed Operators!",
-        "categories": ["cloud"]
+        "categories": ["cloud", "featured"]
     }
 ]


### PR DESCRIPTION
Remove FINOS from topic pages, so that Operator's Corner will show up on the homepage.