### PR TITLE
Fix account dropdown alignment

### DIFF
--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -120,7 +120,7 @@
         <li class="p-navigation__item js-nav-account" id="user-link">
           {# Authenticated #}
           <a href="#user-link-menu" aria-controls="user-link-menu" class="p-navigation__link js-nav-account--authenticated u-hide js-account--name account-name">My account</a>
-          <ul class="p-navigation__dropdown" id="user-link-menu" aria-hidden="true">
+          <ul class="p-navigation__dropdown--right" id="user-link-menu" aria-hidden="true">
             <li>
               <a href="/charms" class="p-navigation__dropdown-item">My charms and bundles</a>
             </li>


### PR DESCRIPTION
## Done
Fixed the alignment of the account dropdown

## How to QA
- Go to https://charmhub-io-1528.demos.haus
- Log in
- Check that the account dropdown is aligned to the right edge