### PR TITLE
WD-2205 Add Kubeflow beta 1.7 banner

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,17 +29,22 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Install requirements
+        run: |
+          sudo apt-get update && sudo apt-get install --yes python3-setuptools
+          sudo pip3 install -r requirements.txt
+
       - name: Install Dotrun
         uses: canonical/install-dotrun@main
 
       - name: Install dependencies
-        run: dotrun install
+        run: /snap/bin/dotrun install
 
       - name: Build assets
-        run: dotrun build
+        run: /snap/bin/dotrun build
 
       - name: Test site
-        run: dotrun & curl --head --fail --retry-delay 1 --retry 30 --retry-connrefused http://localhost:8045
+        run: /snap/bin/dotrun & sleep 10 & curl --head --fail --retry-delay 1 --retry 30 --retry-connrefused http://localhost:8045
 
   check-prettier:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,11 +29,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install requirements
-        run: |
-          sudo apt-get update && sudo apt-get install --yes python3-setuptools
-          sudo pip3 install -r requirements.txt
-
       - name: Install Dotrun
         uses: canonical/install-dotrun@main
 
@@ -44,7 +39,7 @@ jobs:
         run: /snap/bin/dotrun build
 
       - name: Test site
-        run: /snap/bin/dotrun & sleep 10 & curl --head --fail --retry-delay 1 --retry 30 --retry-connrefused http://localhost:8045
+        run: /snap/bin/dotrun & sleep 10 && curl --head --fail --retry-delay 1 --retry 30 --retry-connrefused http://localhost:8045
 
   check-prettier:
     runs-on: ubuntu-latest

--- a/templates/details/_details-header.html
+++ b/templates/details/_details-header.html
@@ -1,4 +1,7 @@
 <div class="p-strip--light is-shallow">
+  {% if request.path.startswith("/kubeflow") and schedule_banner("2023-03-08", "2023-03-22") %}
+    {% include "partial/_kubeflow-beta-banner.html" %}
+  {% endif %}
   <div class="row">
     <div class="col-8">
       <div class="p-charm-header">

--- a/templates/partial/_kubeflow-beta-banner.html
+++ b/templates/partial/_kubeflow-beta-banner.html
@@ -1,0 +1,15 @@
+<div class="u-fixed-width">
+  <div class="p-notification--information is-inline">
+    <div class="p-notification__content">
+      <h5 class="p-notification__title">
+        The Charmed Kubeflow 1.7 beta is here:
+      </h5>
+      <p class="p-notification__message">
+        Read more in our
+        <a href="https://ubuntu.com/blog/kubeflow-1-7-beta-release">blog</a> and share your
+        <a href="https://discourse.charmhub.io/t/charmed-kubeflow-1-7-beta-is-here/8791">feedback</a>
+        with us.
+      </p>
+    </div>
+  </div>
+</div>

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,16 @@
+from unittest import TestCase
+from webapp.helpers import schedule_banner
+
+
+class TestContextFunctions(TestCase):
+    def test_schedule_banner(self):
+        """
+        Test schedule banner should return True
+        if provided dates are within the timeframe
+        """
+
+        # Case 1: dates passed, banner should be down
+        self.assertFalse(schedule_banner("2021-02-28", "2022-02-28"))
+
+        # Case 2: dates did not pass, banner should be up
+        self.assertTrue(schedule_banner("2023-02-28", "2100-02-28"))

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -34,6 +34,7 @@ def set_handlers(app):
             "remove_filter": helpers.remove_filter,
             "account": account,
             "image": image_template,
+            "schedule_banner": helpers.schedule_banner,
         }
 
     # Error handlers

--- a/webapp/helpers.py
+++ b/webapp/helpers.py
@@ -7,7 +7,7 @@ from flask import request
 from ruamel.yaml import YAML
 from slugify import slugify
 from talisker import requests
-
+from datetime import datetime
 
 session = requests.get_session()
 discourse_api = DiscourseAPI(
@@ -183,3 +183,13 @@ def modify_headers(soup, decrease_step=2):
         add_header_id(header, levels)
 
     return soup
+
+
+def schedule_banner(start_date: str, end_date: str):
+    try:
+        end = datetime.strptime(end_date, "%Y-%m-%d")
+        start = datetime.strptime(start_date, "%Y-%m-%d")
+        present = datetime.now()
+        return start <= present < end
+    except ValueError:
+        return False


### PR DESCRIPTION
## Done

Sites tribe [got a request](https://docs.google.com/document/d/19_9cUiyjxWXPvLaZc0_DOglsCQwlJFW8gET7sZt7IYI/edit#) to add this Kubeflow 1.7 beta banner

This banner is scheduled to be up on 8th of March and be taken down on 22nd of March (check the brief linked previously).

I've also fixed your dotrun issue, I think it just needs some time to be able to `curl`, dotrun is probably doing stuff

## How to QA

- Navigate to https://charmhub-io-1529.demos.haus/kubeflow
- Click on the links.


## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-2205?atlOrigin=eyJpIjoiNGMzNjRhODYxZDY5NDFhMzhlMDllMzExMzE0MzRjODgiLCJwIjoiaiJ9

## Screenshots

![image](https://user-images.githubusercontent.com/14939793/222092958-a5d0edd1-bc01-4eee-aad9-9341f8767f49.png)

