### PR TITLE
Swap provides and consumes on integrations tab

### DIFF
--- a/static/js/src/public/details/integrations/components/InterfaceItem.tsx
+++ b/static/js/src/public/details/integrations/components/InterfaceItem.tsx
@@ -148,7 +148,7 @@ export const InterfaceItem = ({
         <>
           <p>
             Charms that{" "}
-            <b>{interfaceType === "requires" ? "provide" : "consume"}</b>{" "}
+            <b>{interfaceType === "requires" ? "consume" : "provide"}</b>{" "}
             {interfaceData.interface}
           </p>
           <Row>


### PR DESCRIPTION
## Done
Swapped the provides and consumes on the integrations tab

## How to QA
- Go to https://charmhub-io-1532.demos.haus/mysql-k8s/integrations
- Check that "provide" and "consume" are the opposite way around ([compare to live](https://charmhub.io/mysql-k8s/integrations))

## Issue / Card
Fixes #1531
Fixes https://warthogs.atlassian.net/browse/WD-2374
