### PR TITLE
Link directly to discourse post about how to write a topic page

### DIFF
--- a/templates/topics/document.html
+++ b/templates/topics/document.html
@@ -83,7 +83,7 @@
           {% endif %}
         {% endfor %}
         </div>
-        <a href="https://juju.is/tutorials/how-to-write-a-topic-page" class="p-button--positive p-topics-contribute__button">How to contribute a Topic</a>
+        <a href="https://discourse.charmhub.io/t/how-to-write-a-topic-page/5442" class="p-button--positive p-topics-contribute__button">How to contribute a Topic</a>
       </nav>
     </aside>
     <main class="col-9" id="main-content">

--- a/templates/topics/index.html
+++ b/templates/topics/index.html
@@ -13,7 +13,7 @@
     <div class="col-8">
       <p>Topic pages provide a rich list of solutions for Charmhub users. These pages include a range of content relevant to that subject, from charms and bundles to tutorials and documentation. Looking to explore a topic that you are interested in? See the list below to get started. Are you a publisher wanting to improve the visibility of your charms, or see a topic that is missing? Click the button below to contribute and feature your favourite charms and bundles.</p>
       <p>
-        <a href="https://juju.is/tutorials/how-to-write-a-topic-page" class="p-button--positive">Contribute a Topic</a>
+        <a href="https://discourse.charmhub.io/t/how-to-write-a-topic-page/5442" class="p-button--positive">Contribute a Topic</a>
       </p>
     </div>
   </div>


### PR DESCRIPTION
## Done
- Replace tutorial link with direct link to discourse.

## How to QA
Visit https://charmhub-io-1533.demos.haus/topics, the "Contribute a Topic" link should go to [discourse](https://discourse.charmhub.io/t/how-to-write-a-topic-page/5442)
Visit https://charmhub-io-1533.demos.haus/topics/canonical-observability-stack, the "How to contribute a Topic" link should go to [discourse](https://discourse.charmhub.io/t/how-to-write-a-topic-page/5442) 

Fixes: https://warthogs.atlassian.net/browse/WD-2402
