### PR TITLE
Remove JAAS link from navigation

### DIFF
--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -107,9 +107,6 @@
             </li>
           </ul>
         </li>
-        <li class="p-navigation__item">
-          <a class="p-navigation__link" href="https://jaas.ai">JAAS</a>
-        </li>
       </ul>
       <ul class="p-navigation__items global-nav">
         <li class="p-navigation__item">


### PR DESCRIPTION
## Done

Removed JAAS from navigation

## QA
- Go to https://charmhub-io-1534.demos.haus/
- Check that JAAS is not in the navigation

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-2404
