### PR TITLE
add sub-navigation to a Documention dropdown list

### DIFF
--- a/static/sass/_pattern_p-navigation.scss
+++ b/static/sass/_pattern_p-navigation.scss
@@ -15,12 +15,7 @@
     }
   }
 
-  ul.p-navigation__sub-list {
-    margin-left: 0 !important;
-    padding-left: 0 !important;
-  }
-
   ul.p-navigation__sub-list .p-navigation__dropdown-item {
-    padding-left: 2rem !important;
+    padding-left: 2rem;
   }
 }

--- a/static/sass/_pattern_p-navigation.scss
+++ b/static/sass/_pattern_p-navigation.scss
@@ -14,4 +14,13 @@
       padding-bottom: 0.75rem;
     }
   }
+
+  ul.p-navigation__sub-list {
+    margin-left: 0 !important;
+    padding-left: 0 !important;
+  }
+
+  ul.p-navigation__sub-list .p-navigation__dropdown-item {
+    padding-left: 2rem !important;
+  }
 }

--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -31,7 +31,7 @@
               <a href="https://juju.is/docs" class="p-navigation__dropdown-item">
                 Documentation
               </a>
-              <ul class="p-navigation__sub-list">
+              <ul>
                 <li>
                   <a class="p-navigation__dropdown-item" href="https://juju.is/docs/olm">OLM docs: Manage charms</a>
                 </li>

--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -28,33 +28,26 @@
           <a class="p-navigation__link" href="#learn-link-menu" aria-controls="learn-link-menu">Learn</a>
           <ul class="p-navigation__dropdown" id="learn-link-menu" aria-hidden="true">
             <li>
-              <div class="p-navigation__dropdown-item is-title">
-                <div class="p-muted-heading u-no-margin--bottom">
-                  Documentation
-                </div>
-              </div>
-            </li>
-            <li>
-              <a class="p-navigation__dropdown-item" href="https://juju.is/docs/olm">OLM docs: Manage charms</a>
-            </li>
-            <li>
-              <a class="p-navigation__dropdown-item" href="https://juju.is/docs/sdk">SDK docs: Build charms</a>
-            </li>
-            <li>
-              <a class="p-navigation__dropdown-item" href="https://juju.is/docs/dev">Dev docs: Contribute to the OLM</a>
-            </li>
-            {#<li>
-              <a class="p-navigation__dropdown-item" href="https://charmhub.io/interfaces">Interfaces</a>
-            </li>#}
-            <li>
-              <a class="p-navigation__dropdown-item" href="https://juju.is/tutorials">Tutorials</a>
-            </li>
-            <li>
-              <div class="p-navigation__dropdown-item is-title">
-                <div class="p-muted-heading u-no-margin--bottom">
-                  Resources
-                </div>
-              </div>
+              <a href="https://juju.is/docs" class="p-navigation__dropdown-item">
+                Documentation
+              </a>
+              <ul class="p-navigation__sub-list">
+                <li>
+                  <a class="p-navigation__dropdown-item" href="https://juju.is/docs/olm">OLM docs: Manage charms</a>
+                </li>
+                <li>
+                  <a class="p-navigation__dropdown-item" href="https://juju.is/docs/sdk">SDK docs: Build charms</a>
+                </li>
+                <li>
+                  <a class="p-navigation__dropdown-item" href="https://juju.is/docs/dev">Dev docs: Contribute to the OLM</a>
+                </li>
+                {#<li>
+                  <a class="p-navigation__dropdown-item" href="https://charmhub.io/interfaces">Interfaces</a>
+                </li>
+                <li>
+                  <a class="p-navigation__dropdown-item" href="https://juju.is/tutorials">Tutorials</a>
+                </li>#}
+              </ul>
             </li>
             <li>
               <a class="p-navigation__dropdown-item" href="https://juju.is/cloud-native-kubernetes-usage-report-2022">Kubernetes & Cloud Native Operations Report</a>

--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -29,9 +29,9 @@
           <ul class="p-navigation__dropdown" id="learn-link-menu" aria-hidden="true">
             <li>
               <a href="https://juju.is/docs" class="p-navigation__dropdown-item">
-                Documentation
+              Documentation
               </a>
-              <ul>
+              <ul class="p-navigation__sub-list u-no-margin--left u-no-padding--left">
                 <li>
                   <a class="p-navigation__dropdown-item" href="https://juju.is/docs/olm">OLM docs: Manage charms</a>
                 </li>


### PR DESCRIPTION
## Done
added a sub-navigation to a Documentation dropdown list

## How to QA
- Go to https://charmhub-io-1536.demos.haus/
- Click "Learn" navigation item
- Check if you see a sub-navigation under "Documentation"

## Issue / Card
Fixes #https://warthogs.atlassian.net/browse/WD-2393

## Screenshots
<img width="1160" alt="Screen Shot 2023-03-13 at 5 11 59 PM" src="https://user-images.githubusercontent.com/90341644/224775732-398f4671-9082-4caf-8d71-48e86d1f511f.png">

