### PR TITLE
removed version from channel map

### DIFF
--- a/templates/partial/_channel-map.html
+++ b/templates/partial/_channel-map.html
@@ -30,7 +30,6 @@
             <thead>
               <tr>
                 <th>Channel</th>
-                <th>Version</th>
                 <th>Revision</th>
                 <th>Published</th>
                 <th>Runs on</th>
@@ -41,7 +40,6 @@
               {% for channel, channel_data in track_data.items() %}
               <tr data-channel-map-track="{{ track }}" data-channel-map-channel="{{ channel }}" data-channel-map-version="{{ channel_data.latest.version }}" data-channel-map-filter="{% for release, release_data in channel_data.releases.items() %}{% for arch in release_data.architectures %} {{ arch }} {% endfor %}{% endfor %}">
                 <td data-heading="Channel">{{ track }}/{{ channel }}</td>
-                <td data-heading="Version">{{ channel_data.latest.version }}</td>
                 <td data-heading="Revision">{{ channel_data.latest.revision.revision }}</td>
                 <td data-heading="Published">{{ channel_data.latest.released_at }}</td>
                 <td data-heading="Runs on">
@@ -64,7 +62,7 @@
       </div>
     </div>
   </div>
-  
+
   <div class="p-charm-header__code">
     <div class="p-tooltip--information">
       <div>


### PR DESCRIPTION
## Done
removed a version column from a channel map

## How to QA
Go to https://charmhub-io-1546.demos.haus/
Click one of the charms and then a channel name 
See if there is no "version" column 

## Issue / Card
Fixes #https://warthogs.atlassian.net/browse/WD-2562

## Screenshots
<img width="1085" alt="Screen Shot 2023-03-15 at 3 58 10 PM" src="https://user-images.githubusercontent.com/90341644/225368701-2376ef01-ff6f-47f2-850e-25ca4736ec7f.png">
