### PR TITLE
Add new route for beta store

### DIFF
--- a/templates/beta/store.html
+++ b/templates/beta/store.html
@@ -1,0 +1,8 @@
+{% extends 'base_layout.html' %}
+
+{% block meta_description %}Universal operators for application lifecycle management on Linux, Windows and Kubernetes{% endblock %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1mps4SOa8_DA25fccYor3wxwV3ulQiD-uaocDHmaGmhw{% endblock meta_copydoc %}
+
+{% block content %}
+{% endblock content %}

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -9,7 +9,7 @@ from canonicalwebteam.store_api.exceptions import StoreApiResponseErrorList
 from canonicalwebteam.store_api.stores.charmstore import CharmPublisher
 from flask import Blueprint, Response, abort
 from flask import current_app as app
-from flask import jsonify, redirect, render_template, request
+from flask import jsonify, redirect, render_template, request, make_response
 from pybadges import badge
 
 from webapp.config import DETAILS_VIEW_REGEX, CATEGORIES
@@ -851,3 +851,10 @@ def get_charms_from_bundle(entity_name):
         return "Requested object should be a bundle", 400
 
     return jsonify({"charms": package["store_front"]["bundle"]["charms"]})
+
+
+@store.route("/beta-store")
+def beta_store_index():
+    response = make_response(render_template("beta/store.html"))
+    response.headers["X-Robots-Tag"] = "noindex"
+    return response


### PR DESCRIPTION
## Done
Created a new view for the beta store with a `noindex` request header

## How to QA
- Go to https://charmhub-io-1554.demos.haus/beta-store
- Check that there is a page there
- Check that there is a `x-robots-tag` request header set to `noindex`
