### PR TITLE
Remove readme from description tab

### DIFF
--- a/templates/details/overview.html
+++ b/templates/details/overview.html
@@ -17,7 +17,8 @@
         </div>
       {% endif %}
       <div class="js-readme-content">
-        {{ description | safe }}
+        <h4>{{summary | safe }}</h4>
+        <p>{{ description | safe }}</p>
       </div>
     </div>
   </div>

--- a/templates/details/overview.html
+++ b/templates/details/overview.html
@@ -17,7 +17,7 @@
         </div>
       {% endif %}
       <div class="js-readme-content">
-        {{ readme | safe }}
+        {{ description | safe }}
       </div>
     </div>
   </div>

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -483,18 +483,3 @@ def format_slug(slug):
         .replace("And", "and")
         .replace("Iot", "IoT")
     )
-
-
-def parse_readme(readme, channel_request=None):
-    readme = html(readme)
-    readme = re.sub("(<!--.*-->)", "", readme, flags=re.DOTALL)
-    readme = readme.replace("https://charmhub.io/", "/")
-    if channel_request:
-        readme = readme.replace(
-            "/configure", "/configure/?channel={}".format(channel_request)
-        )
-
-    readme = get_soup(readme)
-    readme = modify_headers(readme)
-
-    return readme

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -158,6 +158,7 @@ def details_overview(entity_name):
     if not package["store_front"]["docs_topic"]:
         navigation = None
         description = package["store_front"]["metadata"]["description"]
+        summary = package["store_front"]["metadata"]["summary"]
     else:
 
         docs_url_prefix = f"/{package['name']}/docs"
@@ -222,6 +223,10 @@ def details_overview(entity_name):
 
         context["navigation"] = navigation
     context["description"] = description
+
+    if summary:
+        context["summary"] = summary
+
     context["package_type"] = package["type"]
 
     return render_template("details/overview.html", **context)

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -139,7 +139,6 @@ def details_overview(entity_name):
     channel_request = request.args.get("channel", default=None, type=str)
 
     extra_fields = [
-        "default-release.revision.readme-md",
         "result.bugs-url",
         "result.website",
         "result.summary",
@@ -158,7 +157,9 @@ def details_overview(entity_name):
 
     if not package["store_front"]["docs_topic"]:
         navigation = None
+        description = package["store_front"]["metadata"]["description"]
     else:
+
         docs_url_prefix = f"/{package['name']}/docs"
 
         docs = DocParser(
@@ -167,10 +168,10 @@ def details_overview(entity_name):
             url_prefix=docs_url_prefix,
         )
         docs.parse()
-
         topic = docs.index_topic
 
-        docs.parse_topic(topic)
+        docs_content = docs.parse_topic(topic)
+        description = docs_content.get("body_html", "")
 
         navigation = docs.navigation
 
@@ -220,14 +221,7 @@ def details_overview(entity_name):
             ]
 
         context["navigation"] = navigation
-
-    readme = package["default-release"]["revision"].get(
-        "readme-md", "No readme available"
-    )
-
-    readme = logic.parse_readme(readme, channel_request)
-
-    context["readme"] = readme
+    context["description"] = description
     context["package_type"] = package["type"]
 
     return render_template("details/overview.html", **context)

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -160,7 +160,6 @@ def details_overview(entity_name):
         description = package["store_front"]["metadata"]["description"]
         summary = package["store_front"]["metadata"]["summary"]
     else:
-
         docs_url_prefix = f"/{package['name']}/docs"
 
         docs = DocParser(


### PR DESCRIPTION
## Done
- Remove readme from description tab of package page
- Remove fetching of github readme from the API
- Replace readme with discourse doc or description where discourse docs is not available
## How to QA
- Go `https://charmhub-io-1557.demos.haus/postgresql-k8s` to QA for a package with discourse docs
- Go to `https://charmhub-io-1557.demos.haus/microk8s` to QA for a package without discourse docs
## Issue / Card WD-2563
Fixes #

## Screenshots
