### PR TITLE
Pass the schedule_banner helper to the template

### DIFF
--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -28,6 +28,7 @@ def charmhub_utility_processor():
         "add_filter": helpers.add_filter,
         "active_filter": helpers.active_filter,
         "remove_filter": helpers.remove_filter,
+        "schedule_banner": helpers.schedule_banner,
         "account": account,
         "image": image_template,
     }


### PR DESCRIPTION
## Done

Pass the schedule_banner helper to the template

## How to QA
- Go to /kubeflow
- See it loads and the banner is not present


Probably supersedes: https://github.com/canonical/charmhub.io/pull/1561