### PR TITLE
Show both live and draft interface pages

### DIFF
--- a/static/js/src/interfaces/components/App/App.tsx
+++ b/static/js/src/interfaces/components/App/App.tsx
@@ -13,10 +13,10 @@ function App() {
           path="/interfaces/:interfaceName"
           element={<InterfaceDetails />}
         />
-        <Route
+        {/* <Route
           path="/interfaces/:interfaceName/:interfaceStatus"
           element={<InterfaceDetails />}
-        />
+        /> */}
       </Routes>
     </Router>
   );

--- a/static/js/src/interfaces/components/App/App.tsx
+++ b/static/js/src/interfaces/components/App/App.tsx
@@ -13,10 +13,10 @@ function App() {
           path="/interfaces/:interfaceName"
           element={<InterfaceDetails />}
         />
-        {/* <Route
+         <Route
           path="/interfaces/:interfaceName/:interfaceStatus"
           element={<InterfaceDetails />}
-        /> */}
+        />
       </Routes>
     </Router>
   );

--- a/static/js/src/interfaces/components/App/App.tsx
+++ b/static/js/src/interfaces/components/App/App.tsx
@@ -13,6 +13,10 @@ function App() {
           path="/interfaces/:interfaceName"
           element={<InterfaceDetails />}
         />
+        <Route
+          path="/interfaces/:interfaceName/:interfaceStatus"
+          element={<InterfaceDetails />}
+        />
       </Routes>
     </Router>
   );

--- a/static/js/src/interfaces/components/InterfaceDetails/InterfaceDetails.tsx
+++ b/static/js/src/interfaces/components/InterfaceDetails/InterfaceDetails.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link, useParams, useSearchParams } from "react-router-dom";
 import { useQuery } from "react-query";
 import ReactMarkdown from "react-markdown";
 import remarkMermaid from "remark-mermaidjs";
@@ -87,18 +87,11 @@ const getCharms = async (interfaceName: string): Promise<InterfaceData> => {
 
 const getInterface = async (
   interfaceName: string | undefined,
-  interfaceStatus: string | undefined
+  interfaceStatus: string
 ): Promise<InterfaceData> => {
 
   if (interfaceName) {
-    let response;
-    if (interfaceStatus === "draft") {
-      response = await fetch(`./${interfaceName}.json/${interfaceStatus}`);
-      if (response.status === 404) {
-        response = await fetch(`./${interfaceName}.json`); 
-      }
-    }
-    response = await fetch(`./${interfaceName}.json`);
+    const response = await fetch(`./${interfaceName}/${interfaceStatus}.json`);
     if (response.status === 200) {
       return response.json();
     }
@@ -108,7 +101,10 @@ const getInterface = async (
 };
 
 function InterfaceDetails() {
-  const { interfaceName, interfaceStatus } = useParams();
+  const { interfaceName } = useParams();
+  const [searchParams, setSearchParams]: [URLSearchParams, Function] =
+  useSearchParams();
+  const interfaceStatus = searchParams.get("status") || "live";
   let isCommunity = false;
 
   const hasDeveloperDocumentation = () => {

--- a/static/js/src/interfaces/components/InterfaceDetails/InterfaceDetails.tsx
+++ b/static/js/src/interfaces/components/InterfaceDetails/InterfaceDetails.tsx
@@ -87,24 +87,29 @@ const getCharms = async (interfaceName: string): Promise<InterfaceData> => {
 
 const getInterface = async (
   interfaceName: string | undefined,
-  interfaceStatus: string
+  interfaceStatus?: string | undefined
 ): Promise<InterfaceData> => {
 
   if (interfaceName) {
-    const response = await fetch(`./${interfaceName}/${interfaceStatus}.json`);
+    
+    if (interfaceStatus) {
+      const response = await fetch(`./${interfaceStatus}.json`);
+      if (response.status === 200) {
+        return response.json();
+      }
+    }
+    const response = await fetch(`./${interfaceName}.json`);
     if (response.status === 200) {
       return response.json();
     }
+    
   }
 
   throw new Error("Interface is not a tested interface.");
 };
 
 function InterfaceDetails() {
-  const { interfaceName } = useParams();
-  const [searchParams, setSearchParams]: [URLSearchParams, Function] =
-  useSearchParams();
-  const interfaceStatus = searchParams.get("status") || "live";
+  const { interfaceName, interfaceStatus } = useParams();
   let isCommunity = false;
 
   const hasDeveloperDocumentation = () => {
@@ -118,7 +123,7 @@ function InterfaceDetails() {
     error: interfaceError,
     isLoading: interfaceIsLoading,
   } = useQuery(
-    ["interface", interfaceName, interfaceStatus],
+    ["interface", interfaceName],
     () => getInterface(interfaceName, interfaceStatus),
     {
       refetchOnMount: false,

--- a/static/js/src/interfaces/components/InterfaceDetails/InterfaceDetails.tsx
+++ b/static/js/src/interfaces/components/InterfaceDetails/InterfaceDetails.tsx
@@ -86,10 +86,19 @@ const getCharms = async (interfaceName: string): Promise<InterfaceData> => {
 };
 
 const getInterface = async (
-  interfaceName: string | undefined
+  interfaceName: string | undefined,
+  interfaceStatus: string | undefined
 ): Promise<InterfaceData> => {
+
   if (interfaceName) {
-    const response = await fetch(`./${interfaceName}.json`);
+    let response;
+    if (interfaceStatus === "draft") {
+      response = await fetch(`./${interfaceName}.json/${interfaceStatus}`);
+      if (response.status === 404) {
+        response = await fetch(`./${interfaceName}.json`); 
+      }
+    }
+    response = await fetch(`./${interfaceName}.json`);
     if (response.status === 200) {
       return response.json();
     }
@@ -99,7 +108,7 @@ const getInterface = async (
 };
 
 function InterfaceDetails() {
-  const { interfaceName } = useParams();
+  const { interfaceName, interfaceStatus } = useParams();
   let isCommunity = false;
 
   const hasDeveloperDocumentation = () => {
@@ -113,8 +122,8 @@ function InterfaceDetails() {
     error: interfaceError,
     isLoading: interfaceIsLoading,
   } = useQuery(
-    ["interface", interfaceName],
-    () => getInterface(interfaceName),
+    ["interface", interfaceName, interfaceStatus],
+    () => getInterface(interfaceName, interfaceStatus),
     {
       refetchOnMount: false,
       refetchOnWindowFocus: false,
@@ -147,7 +156,6 @@ function InterfaceDetails() {
     isLoading = charms.isLoading;
     isCommunity = true;
   }
-
   return (
     <>
       <Strip type="light" shallow>

--- a/static/js/src/interfaces/components/InterfacesIndex/InterfacesIndex.tsx
+++ b/static/js/src/interfaces/components/InterfacesIndex/InterfacesIndex.tsx
@@ -185,12 +185,20 @@ function InterfacesIndex() {
                           justifyContent: "space-between",
                         }}
                       >
-                        <Link to={`/interfaces/${item?.name}`}>
-                          {item?.name}
-                        </Link>
-                        {item?.status !== "Live" && (
-                          <StatusLabel>{item?.status}</StatusLabel>
-                        )}
+                        {(item?.status === "Live") 
+                          ? <Link to={`/interfaces/${item?.name}`}>
+                              {item?.name}
+                            </Link>
+                          : (
+                            <>
+                              <Link to={`/interfaces/${item?.name}/${item?.status.toLowerCase()}`}>
+                                {item?.name}
+                              </Link>
+                              <StatusLabel>{item?.status}</StatusLabel>
+                            </>
+                          )
+                        }
+                        
                       </div>
                     ),
                   },

--- a/static/js/src/interfaces/components/InterfacesIndex/InterfacesIndex.tsx
+++ b/static/js/src/interfaces/components/InterfacesIndex/InterfacesIndex.tsx
@@ -185,13 +185,21 @@ function InterfacesIndex() {
                           justifyContent: "space-between",
                         }}
                       >
-                      <Link to={`/interfaces/${item?.name}?status=${item?.status.toLowerCase()}`}>
-                        {item?.name}
-                      </Link>
-                      {item?.status !== "Live" && (
-                        <StatusLabel>{item?.status}</StatusLabel>
-                      )
-                      }
+                        {
+                            item?.status === "Live" && (
+                              <Link to={`/interfaces/${item?.name}`}>
+                              {item?.name}
+                            </Link>
+                            )
+                        }
+                        {item?.status !== "Live" && (
+                          <>
+                            <StatusLabel>{item?.status}</StatusLabel>
+                            <Link to={`/interfaces/${item?.name}/${item?.status.toLowerCase()}`}>
+                            {item?.name}
+                            </Link>
+                          </>
+                        )}
                       </div>
                     ),
                   },

--- a/static/js/src/interfaces/components/InterfacesIndex/InterfacesIndex.tsx
+++ b/static/js/src/interfaces/components/InterfacesIndex/InterfacesIndex.tsx
@@ -185,20 +185,13 @@ function InterfacesIndex() {
                           justifyContent: "space-between",
                         }}
                       >
-                        {(item?.status === "Live") 
-                          ? <Link to={`/interfaces/${item?.name}`}>
-                              {item?.name}
-                            </Link>
-                          : (
-                            <>
-                              <Link to={`/interfaces/${item?.name}/${item?.status.toLowerCase()}`}>
-                                {item?.name}
-                              </Link>
-                              <StatusLabel>{item?.status}</StatusLabel>
-                            </>
-                          )
-                        }
-                        
+                      <Link to={`/interfaces/${item?.name}?status=${item?.status.toLowerCase()}`}>
+                        {item?.name}
+                      </Link>
+                      {item?.status !== "Live" && (
+                        <StatusLabel>{item?.status}</StatusLabel>
+                      )
+                      }
                       </div>
                     ),
                   },

--- a/webapp/interfaces/logic.py
+++ b/webapp/interfaces/logic.py
@@ -8,14 +8,19 @@ github_client = Github(GITHUB_TOKEN)
 repo = github_client.get_repo("canonical/charm-relation-interfaces")
 
 
-def get_interface_latest_version(interfaces, interface, status):
+def get_interface_status(interfaces, interface, status):
     inter = [
         i
         for i in interfaces
         if i["name"] == interface and i["status"].lower() == status
     ]
-    if inter:
-        latest_version = min(inter, key=lambda x: x["version"])
+    return inter
+
+
+def get_interface_latest_version(interfaces, interface, status):
+    interface_has_status = get_interface_status(interfaces, interface, status)
+    if interface_has_status:
+        latest_version = min(interface_has_status, key=lambda x: x["version"])
         return latest_version["version"]
     else:
         return None

--- a/webapp/interfaces/logic.py
+++ b/webapp/interfaces/logic.py
@@ -9,7 +9,11 @@ repo = github_client.get_repo("canonical/charm-relation-interfaces")
 
 
 def get_interface_latest_version(interfaces, interface, status):
-    inter = [i for i in interfaces if i["name"] == interface and i["status"].lower() == status]
+    inter = [
+        i
+        for i in interfaces
+        if i["name"] == interface and i["status"].lower() == status
+    ]
     if inter:
         latest_version = min(inter, key=lambda x: x["version"])
         return latest_version["version"]
@@ -29,7 +33,9 @@ def get_interface_cont_from_repo(interfaces, interface, status, content_type):
 
 
 def get_interface_yml(interfaces, interface, status):
-    content = get_interface_cont_from_repo(interfaces, interface, status, "charms.yaml")
+    content = get_interface_cont_from_repo(
+        interfaces, interface, status, "charms.yaml"
+    )
     if content:
         cont = content[0].decoded_content.decode("utf-8")
         response = get_dict_from_yaml(cont)

--- a/webapp/interfaces/views.py
+++ b/webapp/interfaces/views.py
@@ -1,12 +1,12 @@
 from datetime import datetime
 
-from flask import Blueprint, render_template, make_response, current_app as app
+from flask import Blueprint, render_template, redirect, make_response, current_app as app
 from github import Github
 from os import getenv
 
 from webapp.interfaces.logic import (
     get_public_interfaces_from_readme,
-    get_latest_version,
+    get_interface_latest_version,
     get_short_description_from_readme,
     convert_readme,
     get_interface_name_from_readme,
@@ -26,9 +26,7 @@ GITHUB_TOKEN = getenv("GITHUB_TOKEN")
 
 github_client = Github(GITHUB_TOKEN)
 
-
-@interfaces.route("/interfaces.json")
-def interfaces_json():
+def get_interfaces():
     repo = github_client.get_repo("canonical/charm-relation-interfaces")
     readme = repo.get_contents("README.md").decoded_content.decode("utf-8")
 
@@ -55,6 +53,10 @@ def interfaces_json():
     return response
 
 
+@interfaces.route("/interfaces.json")
+def interfaces_json():
+    return get_interfaces()
+
 @interfaces.route("/interfaces", defaults={"path": ""})
 @interfaces.route("/interfaces/<path:path>")
 def all_interfaces(path):
@@ -63,33 +65,38 @@ def all_interfaces(path):
     return render_template("interfaces/index.html")
 
 
-@interfaces.route("/interfaces/<interface>.json")
-def single_interface(interface):
-    content = get_interface_cont_from_repo(interface, "README.md")
+@interfaces.route("/interfaces/<interface_name>.json", defaults={"status": "live"})
+@interfaces.route("/interfaces/<interface_name>.json/<status>")
+def get_single_interface(interface_name, status):
+    interfaces = get_interfaces().get_json()["interfaces"]
+  
+    version = get_interface_latest_version(interfaces, interface_name, status)
+    if status == "draft" and not version:
+        return redirect("/interfaces/{}.json".format(interface_name))
+    content = get_interface_cont_from_repo(interfaces, interface_name, status, "README.md")
+
     last_modified = datetime.strptime(
         content[0].last_modified, "%a, %d %b %Y %H:%M:%S %Z"
     ).isoformat()
-    version = get_latest_version(interface)
 
     try:
         readme = content[0].decoded_content.decode("utf-8")
         api = app.store_api
-        other_requirers = api.find(requires=[interface]).get("results", [])
-        other_providers = api.find(provides=[interface]).get("results", [])
+        other_requirers = api.find(requires=[interface_name]).get("results", [])
+        other_providers = api.find(provides=[interface_name]).get("results", [])
 
-        res = convert_readme(interface, version, readme, 2)
+        res = convert_readme(interface_name, version, readme, 2)
 
         res["name"] = get_interface_name_from_readme(readme)
-        res["charms"] = get_interface_yml(interface)
+        res["charms"] = get_interface_yml(interfaces, interface_name, status)
         res["version"] = version
         res["other_charms"] = {
             "providers": other_providers,
             "requirers": other_requirers,
         }
         res["last_modified"] = last_modified
-
         response = make_response(res)
-        response.cache_control.max_age = "36000"
+        # response.cache_control.max_age = "36000"
         return response
     except Exception:
         return "An error occurred!"

--- a/webapp/interfaces/views.py
+++ b/webapp/interfaces/views.py
@@ -1,6 +1,12 @@
 from datetime import datetime
 
-from flask import Blueprint, render_template, redirect, make_response, current_app as app
+from flask import (
+    Blueprint,
+    render_template,
+    redirect,
+    make_response,
+    current_app as app,
+)
 from github import Github
 from os import getenv
 
@@ -25,6 +31,7 @@ interfaces = Blueprint(
 GITHUB_TOKEN = getenv("GITHUB_TOKEN")
 
 github_client = Github(GITHUB_TOKEN)
+
 
 def get_interfaces():
     repo = github_client.get_repo("canonical/charm-relation-interfaces")
@@ -57,6 +64,7 @@ def get_interfaces():
 def interfaces_json():
     return get_interfaces()
 
+
 @interfaces.route("/interfaces", defaults={"path": ""})
 @interfaces.route("/interfaces/<path:path>")
 def all_interfaces(path):
@@ -65,15 +73,19 @@ def all_interfaces(path):
     return render_template("interfaces/index.html")
 
 
-@interfaces.route("/interfaces/<interface_name>.json", defaults={"status": "live"})
+@interfaces.route(
+    "/interfaces/<interface_name>.json", defaults={"status": "live"}
+)
 @interfaces.route("/interfaces/<interface_name>.json/<status>")
 def get_single_interface(interface_name, status):
     interfaces = get_interfaces().get_json()["interfaces"]
-  
+
     version = get_interface_latest_version(interfaces, interface_name, status)
     if status == "draft" and not version:
         return redirect("/interfaces/{}.json".format(interface_name))
-    content = get_interface_cont_from_repo(interfaces, interface_name, status, "README.md")
+    content = get_interface_cont_from_repo(
+        interfaces, interface_name, status, "README.md"
+    )
 
     last_modified = datetime.strptime(
         content[0].last_modified, "%a, %d %b %Y %H:%M:%S %Z"
@@ -82,8 +94,12 @@ def get_single_interface(interface_name, status):
     try:
         readme = content[0].decoded_content.decode("utf-8")
         api = app.store_api
-        other_requirers = api.find(requires=[interface_name]).get("results", [])
-        other_providers = api.find(provides=[interface_name]).get("results", [])
+        other_requirers = api.find(requires=[interface_name]).get(
+            "results", []
+        )
+        other_providers = api.find(provides=[interface_name]).get(
+            "results", []
+        )
 
         res = convert_readme(interface_name, version, readme, 2)
 

--- a/webapp/interfaces/views.py
+++ b/webapp/interfaces/views.py
@@ -73,6 +73,7 @@ def all_interfaces(path):
     return render_template("interfaces/index.html")
 
 
+@interfaces.route("/interfaces/<interface_name>.json", defaults={"status": ""})
 @interfaces.route("/interfaces/<interface_name>/<status>.json")
 def get_single_interface(interface_name, status):
     interfaces = get_interfaces().get_json()["interfaces"]


### PR DESCRIPTION
## Done
- add `/interfaces/<interface-name>.json/draft`
- add `/interfaces/<interface-name>/draft`
- if there is no draft version of the interface, redirect to `/interfaces/<interface-name>`
## How to QA
- Go to 
   - `https://charmhub-io-1564.demos.haus/interfaces/tls_certificates/draft.json`
   - `https://charmhub-io-1564.demos.haus/interfaces/tls_certificates/draft`
   - `https://charmhub-io-1564.demos.haus/nterfaces/ingress/draft.json`
 Or any other interface on `https://charmhub-io-1564.demos.haus/interfaces` page
- Ensure both the `json` page and the interface page works well
## Issue / Card WD-2564
Fixes #

## Screenshots
