### PR TITLE
Update beta store cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@canonical/cookie-policy": "3.4.0",
     "@canonical/global-nav": "3.2.4",
     "@canonical/react-components": "0.40.0",
-    "@canonical/store-components": "0.7.0",
+    "@canonical/store-components": "0.8.0",
     "@types/react-dom": "18.0.6",
     "@types/react-router-dom": "5.3.3",
     "autoprefixer": "10.4.13",

--- a/static/js/beta-store/components/Packages/Packages.tsx
+++ b/static/js/beta-store/components/Packages/Packages.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useQuery } from "react-query";
 import { Strip, Row, Col } from "@canonical/react-components";
-import { PackageCard } from "@canonical/store-components";
+import { CharmCard } from "@canonical/store-components";
 
 function Packages() {
   const getPackages = async () => {
@@ -32,8 +32,8 @@ function Packages() {
             {status === "success" &&
               data.length > 0 &&
               data.map((packageData: any) => (
-                <Col size={3}>
-                  <PackageCard key={packageData.id} item={packageData} />
+                <Col size={3} style={{ marginBottom: "1.5rem" }}>
+                  <CharmCard key={packageData.id} data={packageData} />
                 </Col>
               ))}
           </Row>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1245,7 +1245,7 @@
     react-table "7.8.0"
     react-useportal "1.0.17"
 
-"@canonical/store-components@^0.8.0":
+"@canonical/store-components@0.8.0":
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@canonical/store-components/-/store-components-0.8.0.tgz#55c613417d6dee146ab3483d1f28163248a9208c"
   integrity sha512-/ZH82gD9uDpBx+hLtbT/3rmaN4kE1PC8w3z6wTRnHDn4N6QEBwLBRJlX63HigAjOCJOtpRKqPHRY6x1Ke7MvSw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1245,10 +1245,10 @@
     react-table "7.8.0"
     react-useportal "1.0.17"
 
-"@canonical/store-components@0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@canonical/store-components/-/store-components-0.7.0.tgz#a7ade4317348430c52ad4bd4ff420ea16f6e5d71"
-  integrity sha512-jmRBZJRsGV72epaI3GrMzHRgIUBXT6ag2eSgzyGdr2lrybAhiVjeNem9q58H3n+lHzhw2WgaRN2CVaqaOKW61g==
+"@canonical/store-components@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@canonical/store-components/-/store-components-0.8.0.tgz#55c613417d6dee146ab3483d1f28163248a9208c"
+  integrity sha512-/ZH82gD9uDpBx+hLtbT/3rmaN4kE1PC8w3z6wTRnHDn4N6QEBwLBRJlX63HigAjOCJOtpRKqPHRY6x1Ke7MvSw==
   dependencies:
     "@canonical/react-components" "0.40.0"
     "@types/jest" "27.5.2"


### PR DESCRIPTION
## Done
- Updated the beta store cards

## How to QA
- Go to https://charmhub-io-1565.demos.haus/beta-store
- Check that there are cards (the title and some platforms are missing in the API which is a known issue)
