### PR TITLE
refactor fetching of charms.yaml

### DIFF
--- a/static/js/src/interfaces/components/InterfaceDetails/InterfaceDetails.tsx
+++ b/static/js/src/interfaces/components/InterfaceDetails/InterfaceDetails.tsx
@@ -32,8 +32,14 @@ type InterfaceData = {
   };
   Usage: Array<string>;
   charms?: {
-    consumers: Array<string>;
-    providers: Array<string>;
+    consumers: Array<{
+      name: string;
+      url: string;
+    }>;
+    providers: Array<{
+      name: string;
+      url: string;
+    }>;
   };
   other_charms?: {
     providers: Array<{
@@ -323,13 +329,13 @@ function InterfaceDetails() {
                       <h4 className="p-muted-heading">Featured charms</h4>
                       <Row className="u-no-padding--left u-no-padding--right">
                         {interfaceData?.charms?.providers.map((provider) => (
-                          <Col size={3} key={provider}>
+                          <Col size={3} key={provider.name}>
                             <div className="p-card--highlighted">
                               <iframe
                                 className="u-no-margin--bottom"
                                 height={170}
                                 style={{ width: "100%" }}
-                                src={`/${provider}/embedded/interface`}
+                                src={`/${provider.name}/embedded/interface`}
                               />
                             </div>
                           </Col>
@@ -377,13 +383,13 @@ function InterfaceDetails() {
                       <h4 className="p-muted-heading">Featured charms</h4>
                       <Row className="u-no-padding--left u-no-padding--right">
                         {interfaceData?.charms?.consumers.map((consumer) => (
-                          <Col size={3} key={consumer}>
+                          <Col size={3} key={consumer.name}>
                             <div className="p-card--highlighted">
                               <iframe
                                 className="u-no-margin--bottom"
                                 height={170}
                                 style={{ width: "100%" }}
-                                src={`/${consumer}/embedded/interface`}
+                                src={`/${consumer.name}/embedded/interface`}
                               />
                             </div>
                           </Col>

--- a/webapp/interfaces/logic.py
+++ b/webapp/interfaces/logic.py
@@ -1,4 +1,3 @@
-from pprint import pprint
 import re
 from github import Github
 from os import getenv
@@ -10,6 +9,7 @@ GITHUB_TOKEN = getenv("GITHUB_TOKEN")
 github_client = Github(GITHUB_TOKEN)
 repo = github_client.get_repo("canonical/charm-relation-interfaces")
 yaml = get_yaml_loader()
+
 
 def get_latest_version(interface):
     path = "interfaces/{}".format(interface)

--- a/webapp/interfaces/logic.py
+++ b/webapp/interfaces/logic.py
@@ -1,12 +1,15 @@
+from pprint import pprint
 import re
 from github import Github
 from os import getenv
+
+from webapp.helpers import get_yaml_loader
 
 GITHUB_TOKEN = getenv("GITHUB_TOKEN")
 
 github_client = Github(GITHUB_TOKEN)
 repo = github_client.get_repo("canonical/charm-relation-interfaces")
-
+yaml = get_yaml_loader()
 
 def get_latest_version(interface):
     path = "interfaces/{}".format(interface)
@@ -29,28 +32,12 @@ def get_interface_yml(interface):
     content = get_interface_cont_from_repo(interface, "charms.yaml")
     if content:
         cont = content[0].decoded_content.decode("utf-8")
-        response = get_dict_from_yaml(cont)
+        response = yaml.load(cont)
     # if there is no charm
     else:
         response = {"providers": [], "consumers": []}
 
     return response
-
-
-def get_dict_from_yaml(content):
-    content_list = content.split("\n")
-    result = {"providers": [], "consumers": []}
-    for cont in content_list:
-        if ":" in cont:
-            key = re.sub(r"[^a-zA-Z0-9-]", "", cont)
-        else:
-            stripped_cont = cont.strip("- ")
-            if stripped_cont:
-                if key == "providers":
-                    result["providers"].append(stripped_cont)
-                if key == "consumers" or key == "requirers":
-                    result["consumers"].append(stripped_cont)
-    return result
 
 
 def find_between(s, first, last):


### PR DESCRIPTION
## Done
- Refactor fetching of charms.yaml for interfaces
- Update the link on the FE to show the correct charm in the embedded iframe
## How to QA
- Go to `https://charmhub-io-1567.demos.haus/interfaces` and click on any charm, confirm that it shows the provider and consumer charms
## Issue / Card WD-2763
Fixes #

## Screenshots
