### PR TITLE
Remove page parameter from default view of interfaces index

### DIFF
--- a/static/js/src/interfaces/components/InterfacesIndex/InterfacesIndex.tsx
+++ b/static/js/src/interfaces/components/InterfacesIndex/InterfacesIndex.tsx
@@ -82,7 +82,12 @@ function InterfacesIndex() {
   }, []);
 
   useEffect(() => {
-    setSearchParams({ page: currentPageNumber });
+    if (currentPageNumber > 1) {
+      setSearchParams({ page: currentPageNumber });
+    } else {
+      setSearchParams({});
+    }
+
     setCurrentPageIndex(currentPageNumber - 1);
   }, [currentPageNumber]);
 


### PR DESCRIPTION
## Done

## How to QA
- Go to https://charmhub-io-1578.demos.haus/interfaces
- Check that `page=1` is not in the URL if you are on the first page of results

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-3803