### PR TITLE
Fix broken history buttons on interfaces page

### DIFF
--- a/static/js/src/interfaces/components/InterfacesIndex/InterfacesIndex.tsx
+++ b/static/js/src/interfaces/components/InterfacesIndex/InterfacesIndex.tsx
@@ -45,7 +45,9 @@ function InterfacesIndex() {
   const [currentPageNumber, setCurrentPageNumber] = useState(
     parseInt(searchParams.get("page") || "1")
   );
-  const [currentPageIndex, setCurrentPageIndex] = useState(currentPageNumber);
+  const [currentPageIndex, setCurrentPageIndex] = useState(
+    currentPageNumber - 1
+  );
 
   useEffect(() => {
     setLoading(true);
@@ -80,16 +82,6 @@ function InterfacesIndex() {
         setLoading(false);
       });
   }, []);
-
-  useEffect(() => {
-    if (currentPageNumber > 1) {
-      setSearchParams({ page: currentPageNumber });
-    } else {
-      setSearchParams({});
-    }
-
-    setCurrentPageIndex(currentPageNumber - 1);
-  }, [currentPageNumber]);
 
   useEffect(() => {
     setCurrentItems(pageArray(interfaces, ITEMS_PER_PAGE)[currentPageIndex]);
@@ -236,6 +228,13 @@ function InterfacesIndex() {
             itemsPerPage={ITEMS_PER_PAGE}
             paginate={(pageNumber) => {
               setCurrentPageNumber(pageNumber);
+              setCurrentPageIndex(pageNumber - 1);
+
+              if (pageNumber > 1) {
+                setSearchParams({ page: pageNumber });
+              } else {
+                setSearchParams({});
+              }
             }}
             totalItems={interfaces.length}
             scrollToTop


### PR DESCRIPTION
## Done
Fixed the forward button not working on interfaces page

## How to QA
- Go to https://charmhub-io-1579.demos.haus/interfaces
- Click through to an interface
- Go back to the interfaces index page
- Check that the browser forward button works
- Also check that pagination works as expected

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-3804