### PR TITLE
Fix missing developer documentation

### DIFF
--- a/static/js/src/interfaces/components/InterfaceDetails/InterfaceDetails.tsx
+++ b/static/js/src/interfaces/components/InterfaceDetails/InterfaceDetails.tsx
@@ -76,7 +76,7 @@ function InterfaceDetails() {
 
   const hasDeveloperDocumentation = () => {
     return (
-      interfaceData?.Usage && interfaceData?.Relation && interfaceData?.Behavior
+      interfaceData?.Usage || interfaceData?.Relation || interfaceData?.Behavior
     );
   };
 


### PR DESCRIPTION
## Done
Fixed missing "Developer documentation" section on interface pages

## How to QA
- Go to https://charmhub-io-1580.demos.haus/interfaces/s3/draft
- Check that the "Developer documentation" section is present and contains a mermaid diagram

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-3839