### PR TITLE
Make the backend more robust and update schema

### DIFF
--- a/webapp/interfaces/logic.py
+++ b/webapp/interfaces/logic.py
@@ -8,7 +8,6 @@ from webapp.helpers import get_yaml_loader
 GITHUB_TOKEN = getenv("GITHUB_TOKEN")
 
 github_client = Github(GITHUB_TOKEN)
-repo = github_client.get_repo("canonical/charm-relation-interfaces")
 yaml = get_yaml_loader()
 
 
@@ -56,7 +55,7 @@ class Interfaces:
     def get_interface_cont_from_repo(self, interface, status, content_type):
         version = self.get_interface_latest_version(interface, status)
         interface_path = "interfaces/{}/v{}".format(interface, version)
-        interface_content = repo.get_contents(interface_path)
+        interface_content = self.repo.get_contents(interface_path)
 
         content = [
             path

--- a/webapp/interfaces/logic.py
+++ b/webapp/interfaces/logic.py
@@ -293,4 +293,3 @@ class Interfaces:
     def get_interface_name_from_readme(self, text):
         name = re.sub(r"[#` \n]", "", text.split("\n##", 1)[0]).split("/")[0]
         return name
-

--- a/webapp/interfaces/logic.py
+++ b/webapp/interfaces/logic.py
@@ -12,9 +12,11 @@ yaml = get_yaml_loader()
 
 
 class Interfaces:
+    interfaces = []
+    last_fetch = None
+    repo = None
+
     def __init__(self):
-        self.interfaces = []
-        self.last_fetch = None
         self.repo = github_client.get_repo(
             "canonical/charm-relation-interfaces"
         )
@@ -291,3 +293,4 @@ class Interfaces:
     def get_interface_name_from_readme(self, text):
         name = re.sub(r"[#` \n]", "", text.split("\n##", 1)[0]).split("/")[0]
         return name
+

--- a/webapp/interfaces/logic.py
+++ b/webapp/interfaces/logic.py
@@ -171,10 +171,6 @@ class Interfaces:
 
         return interfaces
 
-        for line in lines:
-            if line and line[0].isalpha():
-                return line
-
     def filter_interfaces_by_status(self, status):
         interfaces = self.get_interfaces()
         return list(
@@ -192,16 +188,6 @@ class Interfaces:
                 return line
 
         return None
-
-    def get_schema_url(self, interface, version, schema):
-        base_link = (
-            "{}https://github.com/canonical/"
-            "charm-relation-interfaces/blob/main/interfaces/{}/{}"
-        ).format("(", interface, version)
-        return base_link.join(schema.split("(."))
-
-    def strip_str(self, string):
-        return re.sub(r"[^a-zA-Z0-9 ().,!-_/:;`]", "", string)
 
     def get_h_content(self, text, pattern):
         start_index = text.index(pattern)

--- a/webapp/interfaces/logic.py
+++ b/webapp/interfaces/logic.py
@@ -11,15 +11,24 @@ github_client = Github(GITHUB_TOKEN)
 repo = github_client.get_repo("canonical/charm-relation-interfaces")
 yaml = get_yaml_loader()
 
+
 class Interfaces:
     def __init__(self):
         self.interfaces = []
         self.last_fetch = None
-        self.repo = github_client.get_repo("canonical/charm-relation-interfaces")
+        self.repo = github_client.get_repo(
+            "canonical/charm-relation-interfaces"
+        )
 
     def get_interfaces(self):
-        if len(self.interfaces) == 0 or not self.last_fetch or time.time() - self.last_fetch > 3600:
-            readme = self.repo.get_contents("README.md").decoded_content.decode("utf-8")
+        if (
+            len(self.interfaces) == 0
+            or not self.last_fetch
+            or time.time() - self.last_fetch > 3600
+        ):
+            readme = self.repo.get_contents(
+                "README.md"
+            ).decoded_content.decode("utf-8")
             self.interfaces = self.get_interfaces_from_readme(readme)
             self.last_fetch = time.time()
 
@@ -34,15 +43,15 @@ class Interfaces:
         ]
         return inter
 
-
     def get_interface_latest_version(self, interface, status):
         interface_has_status = self.get_interface_status(interface, status)
         if interface_has_status:
-            latest_version = min(interface_has_status, key=lambda x: x["version"])
+            latest_version = min(
+                interface_has_status, key=lambda x: x["version"]
+            )
             return latest_version["version"]
         else:
             return None
-
 
     def get_interface_cont_from_repo(self, interface, status, content_type):
         version = self.get_interface_latest_version(interface, status)
@@ -50,10 +59,11 @@ class Interfaces:
         interface_content = repo.get_contents(interface_path)
 
         content = [
-            path for path in interface_content if path.path.endswith(content_type)
+            path
+            for path in interface_content
+            if path.path.endswith(content_type)
         ]
         return content
-
 
     def get_interface_yml(self, interface, status):
         content = self.get_interface_cont_from_repo(
@@ -68,7 +78,6 @@ class Interfaces:
 
         return response
 
-
     def find_between(self, s, first, last):
         try:
             start = s.index(first) + len(first)
@@ -76,7 +85,6 @@ class Interfaces:
             return s[start:end]
         except ValueError:
             return ""
-
 
     def extract_table_from_markdown(self, readme_markdown: str) -> str:
         """
@@ -87,7 +95,6 @@ class Interfaces:
         table_match = re.search(regex, readme_markdown)
         table_str = table_match.group(0)
         return table_str
-
 
     def get_interfaces_from_readme(self, readme):
         """
@@ -105,7 +112,8 @@ class Interfaces:
                 continue
             elif index == 0:
                 keys = [
-                    _i.strip().lower().replace(" ", "_") for _i in line.split("|")
+                    _i.strip().lower().replace(" ", "_")
+                    for _i in line.split("|")
                 ]
             else:
                 data.append(
@@ -169,7 +177,9 @@ class Interfaces:
 
     def filter_interfaces_by_status(self, status):
         interfaces = self.get_interfaces()
-        return list(filter(lambda item: (item["status"] == status), interfaces))
+        return list(
+            filter(lambda item: (item["status"] == status), interfaces)
+        )
 
     def strip_str(self, string):
         return re.sub(r"[^a-zA-Z0-9 ().,!-_/:;`]", "", string)
@@ -193,24 +203,18 @@ class Interfaces:
     def strip_str(self, string):
         return re.sub(r"[^a-zA-Z0-9 ().,!-_/:;`]", "", string)
 
-        if len(headings_and_contents) == 0:
-            return [s.strip("\n") for s in text.split("\n") if s.strip("\n")]
-        resulting_dict = {}
-
     def get_h_content(self, text, pattern):
         start_index = text.index(pattern)
         return [start_index, start_index + len(pattern)]
 
-            if content[0].isalpha and "#" in content:
-                temp[heading] = self.convert_readme(
-                    interface, version, content, level + 1
-                )
-                resulting_dict.update(temp)
-
     def extract_headings_and_content(self, text, level):
-        headings = re.findall(r"^#{" + str(level) + r"}\s.*", text, flags=re.MULTILINE)
+        headings = re.findall(
+            r"^#{" + str(level) + r"}\s.*", text, flags=re.MULTILINE
+        )
 
-        start_end = {heading: self.get_h_content(text, heading) for heading in headings}
+        start_end = {
+            heading: self.get_h_content(text, heading) for heading in headings
+        }
         result = []
         for i in range(len(headings)):
             current_heading = headings[i]
@@ -226,7 +230,6 @@ class Interfaces:
             result.append([current_heading.strip(), body.strip()])
         return result
 
-
     def get_schema_url(self, interface, version, schema):
         base_link = (
             "{}https://github.com/canonical/"
@@ -234,17 +237,16 @@ class Interfaces:
         ).format("(", interface, version)
         return base_link.join(schema.split("(."))
 
-
     def parse_text(self, interface, version, text):
         base_link = (
             "https://github.com/canonical/"
             "charm-relation-interfaces/blob/main/interfaces/{}/v{}"
         ).format(interface, version)
-        pattern = r'\[.*?\]\(.*?\)'
+        pattern = r"\[.*?\]\(.*?\)"
         matches = re.findall(pattern, text)
 
         for match in matches:
-            element_pattern = r'\[(.*?)\]\((.*?)\)'
+            element_pattern = r"\[(.*?)\]\((.*?)\)"
             element_match = re.search(element_pattern, match)
             if element_match:
                 title = element_match.group(1)
@@ -257,7 +259,6 @@ class Interfaces:
 
         return text
 
-
     def convert_readme(self, interface, version, text, level=2):
         headings_and_contents = self.extract_headings_and_content(text, level)
 
@@ -269,11 +270,7 @@ class Interfaces:
         for heading, content in headings_and_contents:
             strip_char = "{}{}".format("#" * level, " ")
             heading = heading.strip(strip_char)
-            _temp = {
-                "heading": heading,
-                "level": level,
-                "children":  []
-            }
+            _temp = {"heading": heading, "level": level, "children": []}
 
             children = []
 
@@ -298,12 +295,13 @@ class Interfaces:
 
             for index, child in list(enumerate(_temp["children"])):
                 if isinstance(child, str):
-                    _temp["children"][index] = self.parse_text(interface, version, child)
+                    _temp["children"][index] = self.parse_text(
+                        interface, version, child
+                    )
 
-            resulting_list.append(_temp);
+            resulting_list.append(_temp)
 
         return resulting_list
-
 
     def get_interface_name_from_readme(self, text):
         name = re.sub(r"[#` \n]", "", text.split("\n##", 1)[0]).split("/")[0]

--- a/webapp/interfaces/views.py
+++ b/webapp/interfaces/views.py
@@ -24,6 +24,7 @@ GITHUB_TOKEN = getenv("GITHUB_TOKEN")
 
 github_client = Github(GITHUB_TOKEN)
 
+
 def get_interfaces():
     interfaces = interface_logic.get_interfaces()
     for i, inter in enumerate(interfaces):
@@ -31,7 +32,9 @@ def get_interfaces():
             interface_readme = interface_logic.repo.get_contents(
                 inter["readme_path"]
             ).decoded_content.decode("utf-8")
-            description = interface_logic.get_short_description_from_readme(interface_readme)
+            description = interface_logic.get_short_description_from_readme(
+                interface_readme
+            )
         except Exception:
             # Some draft interfaces are missing a readme
             description = ""
@@ -63,14 +66,18 @@ def all_interfaces(path):
 @interfaces.route("/interfaces/<interface_name>.json", defaults={"status": ""})
 @interfaces.route("/interfaces/<interface_name>/<status>.json")
 def get_single_interface(interface_name, status):
-    interface_has_status = interface_logic.get_interface_status(interface_name, status)
+    interface_has_status = interface_logic.get_interface_status(
+        interface_name, status
+    )
     # if the user sends request for a status that does not exist
     if not interface_has_status:
         if status == "live":
             status = "draft"
         else:
             status = "live"
-    version = interface_logic.get_interface_latest_version(interface_name, status)
+    version = interface_logic.get_interface_latest_version(
+        interface_name, status
+    )
     content = interface_logic.get_interface_cont_from_repo(
         interface_name, status, "README.md"
     )
@@ -81,14 +88,14 @@ def get_single_interface(interface_name, status):
 
     readme = content[0].decoded_content.decode("utf-8")
     api = app.store_api
-    other_requirers = api.find(requires=[interface_name]).get(
-        "results", []
-    )
-    other_providers = api.find(provides=[interface_name]).get(
-        "results", []
-    )
+    other_requirers = api.find(requires=[interface_name]).get("results", [])
+    other_providers = api.find(provides=[interface_name]).get("results", [])
 
-    res = {"body": interface_logic.convert_readme(interface_name, version, readme, 2)}
+    res = {
+        "body": interface_logic.convert_readme(
+            interface_name, version, readme, 2
+        )
+    }
 
     res["name"] = interface_logic.get_interface_name_from_readme(readme)
     res["charms"] = interface_logic.get_interface_yml(interface_name, status)


### PR DESCRIPTION
## Done
- Added a layer of caching to the `Interfaces` class
- Change the readme format to be a nested list:
```
interface ReadmeSection {
  heading: string;
  level: number;
  content: Array<string | ReadmeSection>
}

type readme = Array<ReadmeSection>
```

## How to QA
- Pull the branch or visit the demo if it's working, and visit http://localhost:8045/interfaces/nginx_route/draft.json
  - The new format (as described above) should be present
  - Each `ReadmeSection` should be in the same order as in the [github file](https://raw.githubusercontent.com/canonical/charm-relation-interfaces/main/interfaces/nginx_route/v0/README.md)
  - relative links `./schema.py` should be fully resolved to the appropriate repo directory
- The endpoint should load a lot quicker

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-3798
Fixes https://warthogs.atlassian.net/browse/WD-3796
Fixes https://warthogs.atlassian.net/browse/WD-3733

## Screenshots
![image](https://github.com/canonical/charmhub.io/assets/479384/494189d3-6a3c-4728-940f-fb222809d688)
