### PR TITLE
Fix charm/bundle list tabs

### DIFF
--- a/templates/publisher/list.html
+++ b/templates/publisher/list.html
@@ -50,10 +50,10 @@
           <nav class="p-tabs" aria-label="Charms and bundles navigation">
             <ul class="p-tabs__list" role="tablist">
               <li class="p-tabs__item" role="presentation">
-                <a href="{{url_for('publisher.list_page')}}" class="p-tabs__link" tabindex="0" role="tab" aria-controls="charms" {% if page_type=='charm' %}aria-selected="true" {% endif %}>Charms</a>
+                <a href="/charms" class="p-tabs__link" tabindex="0" role="tab" aria-controls="charms" {% if page_type=='charm' %}aria-selected="true" {% endif %}>Charms</a>
               </li>
               <li class="p-tabs__item" role="presentation">
-                <a href="{{url_for('publisher.list_page')}}" class="p-tabs__link" role="tab" aria-controls="bundles" {% if page_type=='bundle' %}aria-selected="true" {% endif %}>Bundles</a>
+                <a href="/bundles" class="p-tabs__link" role="tab" aria-controls="bundles" {% if page_type=='bundle' %}aria-selected="true" {% endif %}>Bundles</a>
               </li>
             </ul>
           </nav>


### PR DESCRIPTION
## Done
Hardcode /charms and /bundles links

## How to QA
- Log in
- Click the charms and bundles tabs, they should go to /charms and /bundles respectively
