### PR TITLE
Fix interface page README links

### DIFF
--- a/static/js/src/interfaces/components/CanonicalRelationsMeta/CanonicalRelationsMeta.tsx
+++ b/static/js/src/interfaces/components/CanonicalRelationsMeta/CanonicalRelationsMeta.tsx
@@ -17,7 +17,7 @@ function CanonicalRelationsMeta({ interfaceName, interfaceVersion }: Props) {
       <p>
         <Button
           element="a"
-          href={`https://github.com/canonical/charm-relation-interfaces/blob/main/interfaces/${interfaceName}/${interfaceVersion}/README.md`}
+          href={`https://github.com/canonical/charm-relation-interfaces/blob/main/interfaces/${interfaceName}/v${interfaceVersion}/README.md`}
           appearance="positive"
         >
           Contribute


### PR DESCRIPTION
## Done
Fix README links on interface pages

## QA
- Go to https://charmhub-io-1588.demos.haus/interfaces
- Click through to any interface
- Click the "Contribute" button in the sidebar
- The link should resolve to the correct README