### PR TITLE
Fix back button on interfaces page

### DIFF
--- a/static/js/src/interfaces/components/InterfacesIndex/InterfacesIndex.tsx
+++ b/static/js/src/interfaces/components/InterfacesIndex/InterfacesIndex.tsx
@@ -49,6 +49,18 @@ function InterfacesIndex() {
     currentPageNumber - 1
   );
 
+  const pageParam = searchParams.get("page");
+
+  useEffect(() => {
+    if (pageParam !== null) {
+      setCurrentPageNumber(parseInt(pageParam));
+      setCurrentPageIndex(parseInt(pageParam) - 1);
+    } else {
+      setCurrentPageNumber(1);
+      setCurrentPageIndex(0);
+    }
+  }, [pageParam]);
+
   useEffect(() => {
     setLoading(true);
 


### PR DESCRIPTION
## Done
Fixed an issue where the back button doesn't reload interfaces

## QA
- Go to https://charmhub-io-1589.demos.haus/interfaces
- Click through to the next page
- Use the browsers back button
- You should see the first page of interfaces