### PR TITLE
Support server-side fetching for interfaces

### DIFF
--- a/static/js/src/interfaces/components/App/App.tsx
+++ b/static/js/src/interfaces/components/App/App.tsx
@@ -5,17 +5,22 @@ import InterfacesIndex from "../InterfacesIndex";
 import InterfaceDetails from "../InterfaceDetails";
 
 function App() {
+  const initialProps = window.initialProps;
+
   return (
     <Router>
       <Routes>
-        <Route path="/interfaces" element={<InterfacesIndex />} />
+        <Route
+          path="/interfaces"
+          element={<InterfacesIndex {...initialProps} />}
+        />
         <Route
           path="/interfaces/:interfaceName"
-          element={<InterfaceDetails />}
+          element={<InterfaceDetails {...initialProps} />}
         />
-         <Route
+        <Route
           path="/interfaces/:interfaceName/:interfaceStatus"
-          element={<InterfaceDetails />}
+          element={<InterfaceDetails {...initialProps} />}
         />
       </Routes>
     </Router>

--- a/static/js/src/interfaces/components/InterfaceDetails/InterfaceDetails.tsx
+++ b/static/js/src/interfaces/components/InterfaceDetails/InterfaceDetails.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link, useParams, useSearchParams } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import { useQuery } from "react-query";
 import { formatDistance } from "date-fns";
 import { Strip, Row, Col, Notification } from "@canonical/react-components";
@@ -15,7 +15,6 @@ import RequiringCharms from "../RequiringCharms";
 
 import type { InterfaceData } from "../../types";
 
-
 const getInterface = async (
   interfaceName: string | undefined,
   interfaceStatus?: string | undefined
@@ -25,7 +24,7 @@ const getInterface = async (
       const response = await fetch(`./${interfaceStatus}.json`);
       if (response.status === 200) {
         return response.json();
-      }        
+      }
     }
     const response = await fetch(`./${interfaceName}.json`);
     if (response.status === 200) {
@@ -36,8 +35,20 @@ const getInterface = async (
   throw new Error("Interface is not a tested interface.");
 };
 
-function InterfaceDetails() {
+type Props = {
+  interfaceItem: InterfaceData;
+};
+
+function InterfaceDetails({ interfaceItem }: Props) {
   const { interfaceName, interfaceStatus } = useParams();
+  const shouldFetchData = () => {
+    if (interfaceItem && interfaceItem.name === interfaceName) {
+      return false;
+    }
+
+    return true;
+  };
+
   let isCommunity = false;
 
   let {
@@ -51,12 +62,16 @@ function InterfaceDetails() {
       refetchOnMount: false,
       refetchOnWindowFocus: false,
       refetchOnReconnect: false,
+      enabled: shouldFetchData(),
     }
   );
 
+  if (interfaceItem && interfaceItem.name === interfaceName) {
+    interfaceData = interfaceItem;
+  }
+
   let error = interfaceError as Error;
   let isLoading = interfaceIsLoading;
-
 
   const hasDeveloperDocumentation =
     interfaceData && interfaceData.body ? true : false;
@@ -93,7 +108,7 @@ function InterfaceDetails() {
           </div>
         )}
 
-        {isLoading && (
+        {isLoading && shouldFetchData() && (
           <div className="u-fixed-width u-align--center">
             Fetching interface...
           </div>

--- a/static/js/src/interfaces/index.tsx
+++ b/static/js/src/interfaces/index.tsx
@@ -6,7 +6,7 @@ import App from "./components/App";
 
 const queryClient = new QueryClient();
 
-const root = createRoot(document.getElementById("main-content")!);
+const root = createRoot(document.getElementById("app")!);
 root.render(
   <QueryClientProvider client={queryClient}>
     <App />

--- a/static/js/src/interfaces/types/global.d.ts
+++ b/static/js/src/interfaces/types/global.d.ts
@@ -1,0 +1,10 @@
+import { InterfaceData, InterfaceItem } from "./types";
+
+declare global {
+  interface Window {
+    initialProps: {
+      interfacesList: Array<InterfaceItem>;
+      interfaceItem: InterfaceData;
+    };
+  }
+}

--- a/static/js/src/interfaces/types/index.ts
+++ b/static/js/src/interfaces/types/index.ts
@@ -42,3 +42,11 @@ export type InterfaceData = {
   version: string;
   last_modified: string | null;
 };
+
+export type InterfaceItem = {
+  name: String;
+  description: String;
+  version: String;
+  status: String;
+  category: String;
+};

--- a/templates/interfaces/index.html
+++ b/templates/interfaces/index.html
@@ -4,6 +4,20 @@
 {% block meta_description %}Interfaces describe the relation between two charms. This interface catalogue shows opinionated, standardized interface specifications for charmed operator relations.{% endblock %}
 
 {% block content %}
-<main id="main-content"></main>
+<main id="app"></main>
+<script>
+  window.initialProps = {
+    interfacesList: null,
+    interfaceItem: null
+  };
+
+  {% if interfaces %}
+  window.initialProps.interfacesList = {{ interfaces|safe }};
+  {% endif %}
+
+  {% if interface %}
+  window.initialProps.interfaceItem = {{ interface|safe }}
+  {% endif %}
+</script>
 <script src="{{ versioned_static('js/dist/interfaces.js') }}"></script>
 {% endblock %}

--- a/webapp/interfaces/views.py
+++ b/webapp/interfaces/views.py
@@ -57,11 +57,27 @@ def interfaces_json():
 
 
 @interfaces.route("/interfaces", defaults={"path": ""})
-@interfaces.route("/interfaces/<path:path>")
 def all_interfaces(path):
     if not getenv("ENVIRONMENT") in ["devel", "staging"]:
         return render_template("404.html")
-    return render_template("interfaces/index.html")
+
+    response = get_interfaces()
+    interfaces = eval(response.data.decode("utf-8"))
+    context = {"interfaces": interfaces["interfaces"]}
+
+    return render_template("interfaces/index.html", **context)
+
+
+@interfaces.route("/interfaces/<path:path>")
+def single_interface(path):
+    if not getenv("ENVIRONMENT") in ["devel", "staging"]:
+        return render_template("404.html")
+
+    response = get_single_interface(path, "")
+    interface = eval(response.data.decode("utf-8"))
+    context = {"interface": interface}
+
+    return render_template("interfaces/index.html", **context)
 
 
 @interfaces.route("/interfaces/<interface_name>.json", defaults={"status": ""})


### PR DESCRIPTION
## Done
Support server-side fetching for interfaces

## How to QA
- Go to https://charmhub-io-1592.demos.haus/interfaces
- Check the network tab to see that a request hasn't been made to `interfaces.json`
- Click through to an interface
- Check the network tab to see that a request **has** been made to `<interface_name>.json`
- Reload the interface page
- Check the network tab to see that a request hasn't been made to `<interface_name>.json`

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-4146