### PR TITLE
Enable public facing metadata links

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ beautifulsoup4==4.11.1
 canonicalwebteam.candid==0.9.0
 canonicalwebteam.discourse==5.4.2
 canonicalwebteam.image-template==1.3.1
-canonicalwebteam.store-api==4.1.0
+canonicalwebteam.store-api==4.2.0
 canonicalwebteam.docstring-extractor==1.2.0
 canonicalwebteam.store-base==0.0.2
 Flask-WTF==1.0.1

--- a/templates/details/_side-nav.html
+++ b/templates/details/_side-nav.html
@@ -100,6 +100,27 @@
   </ul>
   <hr class="p-separator--shallow" />
 {% endif %}
+<!-- Once `links` is fully ready we can remove the `request.args` check -->
+{% if package["result"]["links"] and request.args.get("show_metadata_links") %}
+  {% if package["result"]["links"]["website"] %}
+  <h2 class="p-heading--5 u-no-margin--bottom">Websites</h2>
+    <ul class="p-list">
+      {% for contact in package["result"]["links"]["website"] %}
+      <li><a href="{{ website }}">{{ website }}</a></li>
+      {% endfor %}
+    </ul>
+    <hr class="p-separator--shallow" />
+  {% endif %}
+  {% if package["result"]["links"]["contact"] %}
+    <h2 class="p-heading--5 u-no-margin--bottom">Contact</h2>
+    <ul class="p-list">
+      {% for contact in package["result"]["links"]["contact"] %}
+      <li><a href="{{ contact }}">{{ contact|replace('mailto:', '') }}</a></li>
+      {% endfor %}
+    </ul>
+    <hr class="p-separator--shallow" />
+  {% endif %}
+{% endif %}
 {% if not navigation %}
   <a class="p-button--positive u-no-margin--bottom" href="https://juju.is/docs/sdk/add-docs-to-your-charmhub-page">Add docs to a charm</a>
   <hr class="p-separator--shallow" />

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -144,6 +144,7 @@ def details_overview(entity_name):
         "result.website",
         "result.summary",
         "default-release.revision.metadata-yaml",
+        "result.links",
     ]
 
     package = get_package(


### PR DESCRIPTION
## Done
Enabled metadata links on Charm detail pages

## How to QA
- Go to https://charmhub-io-1601.demos.haus/test-charm-steve?show_metadata_links=true
- Check that there is a "Contact" section in the sidebar

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-4428