### PR TITLE
Allow `/t/<id>` format for docs

### DIFF
--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -288,8 +288,9 @@ def get_docs_topic_id(metadata_yaml):
         if docs_link.startswith(base_url):
             docs_link_parts = docs_link[len(base_url) :].split("/")
 
-            if len(docs_link_parts) > 3:
-                topic_id = docs_link_parts[3]
+            if len(docs_link_parts) > 2:
+                topic_id = docs_link_parts[-1]
+                print(topic_id)
 
                 if topic_id.isnumeric():
                     return topic_id

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -290,7 +290,6 @@ def get_docs_topic_id(metadata_yaml):
 
             if len(docs_link_parts) > 2:
                 topic_id = docs_link_parts[-1]
-                print(topic_id)
 
                 if topic_id.isnumeric():
                     return topic_id


### PR DESCRIPTION
## Done
- Allow `/t/<id>` style discourse links (alongside `/t/<post-slug>/<id>` style)

## How to QA
- Visit https://charmhub-io-1605.demos.haus/minio?channel=edge
- Documentation should work
- Documentation doesn't work for https://charmhub.io/minio?channel=edge
