### PR TITLE
Temporary fix to use first "issues" instead of "bug-url"

### DIFF
--- a/templates/details/_side-nav.html
+++ b/templates/details/_side-nav.html
@@ -87,7 +87,11 @@
         <a href="{{ package.result.repository }}"><i class="p-icon--repository"></i>&nbsp;&nbsp;Repository</a>
       </li>
     {% endif %}
-    {% if package.result["bugs-url"] %}
+    {% if package["store_front"]["metadata"]["issues"] %}
+      <li class="p-list__item">
+        <a href="{{ package["store_front"]["metadata"]["issues"][0] }}"><i class="p-icon--bug"></i>&nbsp;&nbsp;Submit a bug</a>
+      </li>
+    {% elif package.result["bugs-url"] %}
       <li class="p-list__item">
         <a href="{{ package.result["bugs-url"] }}"><i class="p-icon--bug"></i>&nbsp;&nbsp;Submit a bug</a>
       </li>

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -382,6 +382,15 @@ def add_store_front_data(package, details=False):
         if "summary" in package["result"]:
             extra["summary"] = package["result"]["summary"]
 
+        # Handle issues and website keys
+        if "issues" in extra["metadata"]:
+            if not isinstance(extra["metadata"]["issues"], list):
+                extra["metadata"]["issues"] = [extra["metadata"]["issues"]]
+
+        if "website" in extra["metadata"]:
+            if not isinstance(extra["metadata"]["website"], list):
+                extra["metadata"]["website"] = [extra["metadata"]["website"]]
+
     package["store_front"] = extra
     return package
 


### PR DESCRIPTION
## Done
- Temporarily patched the UI to show the first item in the "issues" key, if present 

**Why temporary?** Once the "Metadata links" work is complete on the store-side we will no longer need this code.

## How to QA
- Visit https://charmhub-io-1611.demos.haus/postgresql?channel=14/edge
  - The "Submit a bug" link should go to github
- Visit https://charmhub-io-1611.demos.haus/postgresql
  - The "Submit a bug" link should go to launchpad

## Issue / Card
Fixes https://github.com/canonical/charmhub.io/issues/1591