### PR TITLE
Fix cards and loading cards showing at the same time

### DIFF
--- a/static/js/beta-store/components/Packages/Packages.tsx
+++ b/static/js/beta-store/components/Packages/Packages.tsx
@@ -126,7 +126,8 @@ function Packages() {
                   </Col>
                 ))}
 
-              {status === "success" &&
+              {!isFetching &&
+                status === "success" &&
                 data.packages.length > 0 &&
                 data.packages.map((packageData: any) => (
                   <Col

--- a/static/js/beta-store/components/Topics/Topics.tsx
+++ b/static/js/beta-store/components/Topics/Topics.tsx
@@ -43,7 +43,8 @@ function Topics({ topicsQuery }: Props) {
             </Col>
           ))}
 
-        {status === "success" &&
+        {!isFetching &&
+          status === "success" &&
           data.topics.length > 0 &&
           data.topics.map((topic: Topic) => (
             <Col size={3} key={topic.topic_id}>


### PR DESCRIPTION
## Done
Fixed issue where both the package card and loading cards were showing when using the filters

## How to QA
- Go to https://charmhub-io-1616.demos.haus/beta-store
- In dev tools throttle connection (fast 3g should be fine) and disable cache
- Reload the page and use the filters
- Check that loading cards and topics/package cards don't show together

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-4712