### PR TITLE
Show bundle card for bundles on beta store

### DIFF
--- a/static/js/beta-store/components/Packages/Packages.tsx
+++ b/static/js/beta-store/components/Packages/Packages.tsx
@@ -2,7 +2,12 @@ import React, { useState, useEffect } from "react";
 import { useQuery } from "react-query";
 import { useLocation, useSearchParams } from "react-router-dom";
 import { Strip, Row, Col, Pagination } from "@canonical/react-components";
-import { CharmCard, Filters, LoadingCard } from "@canonical/store-components";
+import {
+  CharmCard,
+  BundleCard,
+  Filters,
+  LoadingCard,
+} from "@canonical/store-components";
 
 import Banner from "../Banner";
 import Topics from "../Topics";
@@ -135,7 +140,11 @@ function Packages() {
                     style={{ marginBottom: "1.5rem" }}
                     key={packageData.id}
                   >
-                    <CharmCard data={packageData} />
+                    {packageData.package.type === "bundle" ? (
+                      <BundleCard data={packageData} />
+                    ) : (
+                      <CharmCard data={packageData} />
+                    )}
                   </Col>
                 ))}
 


### PR DESCRIPTION
## Done
Show bundle card for bundles on beta store

## How to QA
- Go to https://charmhub-io-1617.demos.haus/beta-store?type=bundle
- Check that the cards have a coloured top border

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-4714