### PR TITLE
Preserve channel in docs

### DIFF
--- a/templates/partial/_macros.html
+++ b/templates/partial/_macros.html
@@ -5,7 +5,7 @@
       {% if element.navlink_href %}
         <a
           class="p-side-navigation__link {% if expandable and element.children %}is-expandable{% endif %}"
-          href="{{ element.navlink_href }}"
+          href="{{ element.navlink_href }}{% if request.args.get('channel') %}?channel={{request.args.get('channel')}}{% endif %}"
           {% if expandable and element.children %}aria-expanded={% if expanded %}"true"{% else %}"false"{% endif %}{% endif %}
           {% if request.path == element.navlink_href %}aria-current="page"{% endif %}
         >{{ element.navlink_text }}</a>


### PR DESCRIPTION
## Done
Preserve channel query string in docs navigation

## How to QA
- Go to https://charmhub-io-1630.demos.haus/traefik-k8s?channel=edge
- Click How to > Troubleshooting “Gateway Address Unavailable in the sidebar navigation
- Check that the docs links in the side navigation preserve the channel query string
