### PR TITLE
Update link from /docs/olm to /docs/juju

### DIFF
--- a/templates/partial/_footer.html
+++ b/templates/partial/_footer.html
@@ -15,7 +15,7 @@
         </li>-->
 
         <li class="p-list__item">
-          <a class="p-link--soft" href="https://juju.is/docs/olm/quick-reference"><small>What are Charms?</small></a>
+          <a class="p-link--soft" href="https://juju.is/docs/juju/reference"><small>What are Charms?</small></a>
         </li>
 
         <li class="p-list__item">

--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -33,7 +33,7 @@
               </a>
               <ul class="p-navigation__sub-list u-no-margin--left u-no-padding--left">
                 <li>
-                  <a class="p-navigation__dropdown-item" href="https://juju.is/docs/olm">Juju docs: Manage charms</a>
+                  <a class="p-navigation__dropdown-item" href="https://juju.is/docs/juju">Juju docs: Manage charms</a>
                 </li>
                 <li>
                   <a class="p-navigation__dropdown-item" href="https://juju.is/docs/sdk">SDK docs: Build charms</a>


### PR DESCRIPTION
## Done
Apply same change as https://github.com/canonical/juju.is/pull/478

## How to QA
Visit the demo - the docs link should go to https://juju.is/docs/juju

