### PR TITLE
change a heading and use a default icon for a charm bundle page

### DIFF
--- a/templates/details/_bundle_icon.html
+++ b/templates/details/_bundle_icon.html
@@ -1,4 +1,4 @@
-<a href="/{{charm.name}}" title="{{charm.title}}" alt="{{charm.name}}" class="p-bundle-icon" id="{{charm.name}}_id" style="background-image: url('https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,c_fill,w_24,h_24/https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg');">{{ charm.title|truncate(2, true, '', 0) }}</a>
+<a href="/{{charm.name}}" title="{{charm.title}}" alt="{{charm.name}}" class="p-bundle-icon" id="{{charm.name}}_id" style="background-image: url('https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,c_fill,w_24,h_24/https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg');"></a>
 <a href="/{{charm.name}}" class="p-bundle-icon-title" id="{{charm.name}}_link">
   {{ charm.title }}
 </a>

--- a/templates/details/overview.html
+++ b/templates/details/overview.html
@@ -9,7 +9,7 @@
     </div>
     <div class="col-9 p-details-tab__content__body">
       {% if package.type == "bundle" %}
-        <h2 class="p-heading--4">Charms</h2>
+        <h2 class="p-heading--4">Charms in the {{ package.store_front["display-name"] }} bundle</h2>
         <div class="row p-bundle-icons">
           {% for charm in package['store_front']['bundle']['charms'] %}
             <div class="col-3 col-medium-3">


### PR DESCRIPTION
## Done
- changed a heading from "Charms" to "Charms in the [bundle_name] bundle" 
- made a charm without an icon use a default icon in a charm bundle page

## How to QA
- go to https://charmhub-io-1637.demos.haus/kubeflow and see if a heading is changed to "Charms in the Kubeflow bundle" and a default icon is used for charms without icons

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-5045
Fixes https://warthogs.atlassian.net/browse/WD-5046

## Screenshot
<img width="1074" alt="Screenshot 2023-07-10 at 4 39 59 PM" src="https://github.com/canonical/charmhub.io/assets/90341644/29b9f312-731a-4b2c-9d0b-e04e4be9c3ba">
