### PR TITLE
Bump store-base to 0.0.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ canonicalwebteam.discourse==5.4.2
 canonicalwebteam.image-template==1.3.1
 canonicalwebteam.store-api==4.2.0
 canonicalwebteam.docstring-extractor==1.2.0
-canonicalwebteam.store-base==0.0.4
+canonicalwebteam.store-base==0.0.6
 Flask-WTF==1.0.1
 humanize==4.4.0
 mistune==2.0.4


### PR DESCRIPTION
## Done
Bump version of store-base to 0.0.6

## How to QA
- Visit https://charmhub-io-1646.demos.haus/beta/kafka/card.json
- The json should be returned

