### PR TITLE
Accurate library version

### DIFF
--- a/templates/details/libraries/libraries_layout.html
+++ b/templates/details/libraries/libraries_layout.html
@@ -77,7 +77,7 @@
                 <i class="p-icon--update">Last updated</i> {{ creation_date }}
               </li>
               <li class="p-inline-list__item">
-                <i class="p-icon--revision">Revision</i> Library version {{ library['api'] }}
+                <i class="p-icon--revision">Revision</i> Library version {{library['api']}}.{{ library['patch'] }}
               </li>
             </ul>
           </li>


### PR DESCRIPTION
## Done
Include library patch param in the tempalte

## How to QA
- Visit the https://charmhub-io-1651.demos.haus/kafka/libraries/kafka_snap
- The library version should show `0.4`
- Compare to https://charmhub.io/kafka/libraries/kafka_snap which shows `0`

## Issue / Card
Fixes #1386 

## Screenshots
![image](https://github.com/canonical/charmhub.io/assets/479384/b775ff43-7159-4442-9fd4-15d040dd7e04)
