### PR TITLE
fix package latest/edge URL breaking

### DIFF
--- a/static/js/src/public/details/channelMap.js
+++ b/static/js/src/public/details/channelMap.js
@@ -22,15 +22,11 @@ const init = (packageName, channelMapButton) => {
     "[data-channel-map-filter]"
   );
 
-  const selectChannel = (track, channel, version) => {
+  const selectChannel = (track, channel) => {
     var page = window.location.pathname;
 
-    if (track === "latest") {
-      if (channel === "stable") {
-        window.location.href = `${page}`;
-      } else {
-        window.location.href = `${page}?channel=${channel}`;
-      }
+    if (track === "latest" && channel === "stable") {
+      window.location.href = `${page}`;
     } else {
       window.location.href = `${page}?channel=${track}/${channel}`;
     }


### PR DESCRIPTION
## Done
- fix package latest/edge URL breaking
## How to QA
- Go to https://charmhub-io-1656.demos.haus/ovn-central click the channel dropdown and select latest/edge, ensure that it routes to https://charmhub-io-1656.demos.haus/ovn-central?channel=latest/edge
- Do the above step with other charms and ensure that it routes to the correct <track>/<channel>
## Issue / Card 
Fixes #1655

## Screenshots
