### PR TITLE
Add filter panel on mobile

### DIFF
--- a/static/js/beta-store/components/Packages/Packages.tsx
+++ b/static/js/beta-store/components/Packages/Packages.tsx
@@ -1,7 +1,13 @@
 import React, { useState, useEffect } from "react";
 import { useQuery } from "react-query";
 import { useLocation, useSearchParams } from "react-router-dom";
-import { Strip, Row, Col, Pagination } from "@canonical/react-components";
+import {
+  Strip,
+  Row,
+  Col,
+  Pagination,
+  Button,
+} from "@canonical/react-components";
 import {
   CharmCard,
   BundleCard,
@@ -67,6 +73,7 @@ function Packages() {
   const { search } = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
 
+  const [hideFilters, setHideFilters] = useState(true);
   const [currentPage, setCurrentPage] = useState(
     searchParams.get("page") || "1"
   );
@@ -85,41 +92,83 @@ function Packages() {
       <Strip>
         <Row>
           <Col size={3}>
-            <Filters
-              categories={categories}
-              selectedCategories={
-                searchParams.get("categories")?.split(",") || []
-              }
-              setSelectedCategories={(items: any) => {
-                if (items.length < 1) {
-                  setSearchParams(
-                    getCurrentSearchParams(searchParams, ["categories", "page"])
-                  );
-                } else {
-                  setSearchParams({
-                    ...getCurrentSearchParams(searchParams, ["page"]),
-                    categories: items.join(","),
-                  });
-                }
+            <Button
+              className="has-icon u-hide--large p-filter-panel__toggle"
+              onClick={() => {
+                setHideFilters(false);
               }}
-              platforms={platforms}
-              selectedPlatform={searchParams.get("platforms") || "all"}
-              setSelectedPlatform={(item: string) => {
-                setSearchParams({
-                  ...getCurrentSearchParams(searchParams, ["page"]),
-                  platforms: item,
-                });
+            >
+              <i className="p-icon--arrow-right"></i>
+              <span>Filters</span>
+            </Button>
+            <div
+              className={`p-filter-panel-overlay u-hide--large ${
+                hideFilters ? "u-hide--small u-hide--medium" : ""
+              }`}
+              onClick={() => {
+                setHideFilters(true);
               }}
-              packageTypes={packageTypes}
-              selectedPackageType={searchParams.get("type") || "all"}
-              setSelectedPackageType={(item: string) => {
-                setSearchParams({
-                  ...getCurrentSearchParams(searchParams, ["page"]),
-                  type: item,
-                });
-              }}
-              disabled={isFetching}
-            />
+            ></div>
+
+            <div
+              className={`p-filter-panel ${
+                !hideFilters ? "p-filter-panel--expanded" : ""
+              }`}
+            >
+              <div className="p-filter-panel__header">
+                <Button
+                  className="has-icon u-hide--large u-no-margin--bottom u-no-padding--left"
+                  appearance="base"
+                  onClick={() => {
+                    setHideFilters(true);
+                  }}
+                >
+                  <i className="p-icon--chevron-down"></i>
+                  <span>Hide filters</span>
+                </Button>
+              </div>
+
+              <div className="p-filter-panel__inner">
+                <Filters
+                  categories={categories}
+                  selectedCategories={
+                    searchParams.get("categories")?.split(",") || []
+                  }
+                  setSelectedCategories={(items: any) => {
+                    if (items.length < 1) {
+                      setSearchParams(
+                        getCurrentSearchParams(searchParams, [
+                          "categories",
+                          "page",
+                        ])
+                      );
+                    } else {
+                      setSearchParams({
+                        ...getCurrentSearchParams(searchParams, ["page"]),
+                        categories: items.join(","),
+                      });
+                    }
+                  }}
+                  platforms={platforms}
+                  selectedPlatform={searchParams.get("platforms") || "all"}
+                  setSelectedPlatform={(item: string) => {
+                    setSearchParams({
+                      ...getCurrentSearchParams(searchParams, ["page"]),
+                      platforms: item,
+                    });
+                  }}
+                  packageTypes={packageTypes}
+                  selectedPackageType={searchParams.get("type") || "all"}
+                  setSelectedPackageType={(item: string) => {
+                    setSearchParams({
+                      ...getCurrentSearchParams(searchParams, ["page"]),
+                      type: item,
+                    });
+                  }}
+                  disabled={isFetching}
+                />
+              </div>
+            </div>
           </Col>
           <Col size={9}>
             <Topics topicsQuery={topicsQuery} />

--- a/static/sass/_pattern_p-filter-panel.scss
+++ b/static/sass/_pattern_p-filter-panel.scss
@@ -1,0 +1,67 @@
+@mixin p-charmhub-filter-panel {
+  .p-filter-panel {
+    @media only screen and (max-width: $breakpoint-large) {
+      background: $color-x-light;
+      height: 100vh;
+      left: 0;
+      position: fixed;
+      top: 0;
+      transform: translateX(-100%);
+      transition: transform 0.3s ease-in;
+      width: 100%;
+      z-index: 100;
+    }
+
+    @media only screen and (min-width: $breakpoint-small) {
+      max-width: 320px;
+    }
+  }
+
+  .p-filter-panel--expanded {
+    @media only screen and (max-width: $breakpoint-large) {
+      transform: translateX(0);
+    }
+  }
+
+  .p-filter-panel-overlay {
+    @media only screen and (min-width: $breakpoint-small) and (max-width: $breakpoint-large) {
+      background-color:
+        rgba(
+          17,
+          17,
+          17,
+          0.85
+        );
+      height: 100vh;
+      left: 0;
+      position: fixed;
+      top: 0;
+      width: 100%;
+      z-index: 10;
+    }
+  }
+
+  .p-filter-panel__toggle {
+    @media only screen and (max-width: $breakpoint-large) {
+      text-align: left;
+      width: 50%;
+    }
+  }
+
+  .p-filter-panel__header {
+    @media only screen and (max-width: $breakpoint-large) {
+      border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+      padding: 0.5rem 1rem;
+
+      i {
+        transform: rotate(90deg);
+      }
+    }
+  }
+
+  .p-filter-panel__inner {
+    @media only screen and (max-width: $breakpoint-large) {
+      padding: 1rem;
+    }
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -142,6 +142,8 @@ $breakpoint-navigation-threshold: 1110px;
 @include p-detail-inline-list;
 @include vf-l-application;
 @include vf-p-icon-status-waiting;
+@import "pattern_p-filter-panel";
+@include p-charmhub-filter-panel;
 
 // Remove table row borders
 .p-table--no-borders tr {


### PR DESCRIPTION
## Done
Added a sliding panel for the filters on the beta store

## How to QA
- Go to https://charmhub-io-1666.demos.haus/beta-store
- Resize to mobile width
- Check that the filters have turned into a sliding panel that can be toggled on and off

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-6231