### PR TITLE
Fix q param being removed when using filters

### DIFF
--- a/static/js/beta-store/components/Packages/Packages.tsx
+++ b/static/js/beta-store/components/Packages/Packages.tsx
@@ -50,6 +50,10 @@ function Packages() {
       currentSearchParams.type = searchParams.get("type");
     }
 
+    if (searchParams.get("q") && !keysToRemove?.includes("q")) {
+      currentSearchParams.q = searchParams.get("q");
+    }
+
     return currentSearchParams;
   };
 


### PR DESCRIPTION
## Done
Fixed the `q` parameter being removed from the URL when the filters are being used

## How to QA
- Go to https://charmhub-io-1668.demos.haus/?q=kafka
- Use the filters and check that the `q` parameter remains in the URL

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-6297