### PR TITLE
fix markdown in charm actions

### DIFF
--- a/templates/details/actions.html
+++ b/templates/details/actions.html
@@ -25,7 +25,7 @@
             <li class="p-list__item" style="margin-bottom: 1rem;" id="{{ action }}">
               <p class="p-heading--4">{{ action }}</p>
               {% if action_data.description %}
-                <p class="u-no-padding--top">{{ action_data.description }}</p>
+                <p class="u-no-padding--top">{{ action_data.description | markdown | safe}}</p>
               {% endif %}
               {% if action_data.params %}
                 <dl>
@@ -38,7 +38,7 @@
                           <span class="vertical-separator">{{ param }}</span>
                           <span class="u-text--muted">{{ param_data.type }}</span>
                         </p>
-                        <p class="u-no-padding--top">{{ param_data.description }}</p>
+                        <p class="u-no-padding--top">{{ param_data.description |markdown | safe }}</p>
                       </li>
                       {% endfor %}
                     </ul>


### PR DESCRIPTION
## Done
- fix markdown in charm actions
## How to QA
- Go to https://charmhub-io-1675.demos.haus/wordpress-k8s/actions and check that the markdown is parsed
## Issue / Card https://warthogs.atlassian.net/browse/WD-6478
Fixes #1545 

## Screenshots
