### PR TITLE
Update Search and Reset buttons in searchbar

### DIFF
--- a/static/js/src/base/navigation.js
+++ b/static/js/src/base/navigation.js
@@ -104,6 +104,7 @@ function initNavigationSearch(element) {
 
     navigation.classList.add("has-search-open");
     searchInput.focus();
+    searchInput.select();
     document.addEventListener("keyup", keyPressHandler);
   }
 

--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -128,8 +128,8 @@
       <div class="p-navigation__search">
         <form class="p-search-box" action="/" data-js="search-handler-desktop">
           <input type="search" data-js="search-input-desktop" class="p-search-box__input" name="q" aria-label="Search Charmhub" placeholder="Search Charmhub" required>
-          <button type="reset" class="p-search-box__reset"><i class="p-icon--close"></i><span class="u-offscreen">Reset</span></button>
-          <button type="submit" class="p-search-box__button"><i class="p-icon--search"></i><span class="u-offscreen">Search</span></button>
+          <button type="reset" class="p-search-box__reset"><i class="p-icon--close">Reset</i></button>
+          <button type="submit" class="p-search-box__button"><i class="p-icon--search">Search</i></button>
         </form>
       </div>
     </nav>


### PR DESCRIPTION
## Done
- Updated search and reset buttons in navigation
- Auto select the text when opening the search bar

## How to QA
- Visit [demo](https://charmhub-io-1678.demos.haus/)
- Open search box, the search icon should be displayed without text
- Search for something
- Open the search box, the search icon should be displayed without text, the reset icon should be displayed without text

## Issue / Card
Fixes https://github.com/canonical/charmhub.io/issues/1669

## Screenshots
### Before
![image](https://github.com/canonical/charmhub.io/assets/479384/bca894eb-c4a3-42cc-8607-df46017aa52a)

### After
![image](https://github.com/canonical/charmhub.io/assets/479384/a0bff46f-859b-4318-93af-8627295afadb)
