### PR TITLE
Minimise docs footers

### DIFF
--- a/templates/details/docs.html
+++ b/templates/details/docs.html
@@ -12,17 +12,11 @@
     <div class="col-9 p-details-tab__content__body">
       {{ body_html | safe }}
       <hr class="p-separator--medium" />
-      <div class="u-fixed-width">
-        <h4>Help us improve this documentation</h4>
-        <p>
-          Most of this documentation can be collaboratively discussed and changed on the respective topic in the doc category of the <a href="{{ forum_url }}" class="p-link--external">Charmhub forum</a>. See the <a href="https://discourse.charmhub.io/t/how-to-write-docs-our-documentation-guidelines-for-contributors/1245" class="p-link--external">documentation guidelines</a> if you’d like to contribute.
-        </p>
-        <div class="p-notification--information">
-          <div class="p-notification__content">
-            <p class="p-notification__message">
-              Last updated {{ last_update }}. <a href="{{ forum_url }}{{ topic_path }}" class="p-link--external">Help improve this document in the forum</a>.
-            </p>
-          </div>
+      <div class="p-notification--information">
+        <div class="p-notification__content">
+          <p class="p-notification__message">
+            <a href="{{ forum_url }}{{ topic_path }}" class="p-link--external">Help improve this document in the forum</a> (<a href="https://discourse.charmhub.io/t/how-to-write-docs-our-documentation-guidelines-for-contributors/1245" class="p-link--external">guidelines</a>). Last updated {{ last_update }}. 
+          </p>
         </div>
       </div>
     </div>

--- a/templates/details/overview.html
+++ b/templates/details/overview.html
@@ -30,17 +30,11 @@
       </div>
       {% if topic_path %}
         <hr class="p-separator--medium" />
-        <div class="u-fixed-width">
-          <h4>Help us improve this documentation</h4>
-          <p>
-            Most of this documentation can be collaboratively discussed and changed on the respective topic in the doc category of the <a href="{{ forum_url }}" class="p-link--external">Charmhub forum</a>. See the <a href="https://discourse.charmhub.io/t/how-to-write-docs-our-documentation-guidelines-for-contributors/1245" class="p-link--external">documentation guidelines</a> if you’d like to contribute.
-          </p>
-          <div class="p-notification--information">
-            <div class="p-notification__content">
-              <p class="p-notification__message">
-                Last updated {{ last_update }}. <a href="{{ forum_url }}{{ topic_path}}" class="p-link--external">Help improve this document in the forum</a>.
-              </p>
-            </div>
+        <div class="p-notification--information">
+          <div class="p-notification__content">
+            <p class="p-notification__message">
+              <a href="{{ forum_url }}{{ topic_path }}" class="p-link--external">Help improve this document in the forum</a> (<a href="https://discourse.charmhub.io/t/how-to-write-docs-our-documentation-guidelines-for-contributors/1245" class="p-link--external">guidelines</a>). Last updated {{ last_update }}. 
+            </p>
           </div>
         </div>
       {% endif %}


### PR DESCRIPTION
## Done
Make the docs footers more compact.

## How to QA
Visit https://charmhub-io-1679.demos.haus/mysql
Scroll down to the bottom of the documentation
See a shorter summary compared to https://charmhub.io/mysql

## Issue / Card
Fixes https://github.com/canonical/charmhub.io/issues/1661

## Screenshots
