### PR TITLE
Ensure channel persists on all navigation items

### DIFF
--- a/templates/details/configure-bundle.html
+++ b/templates/details/configure-bundle.html
@@ -10,7 +10,7 @@
       <ul class="p-side-navigation__list">
         {% for charm in package.store_front.bundle.charms %}
         <li class="p-side-navigation__item">
-          <a href="{{ charm.name }}" class="p-side-navigation__link u-truncate{% if subpackage_path == charm.name %} is-active{% endif %}" role="tab" aria-controls="{{ charm.name }}" aria-selected="{% if subpackage.name == charm.name %}true{% else %}false{% endif %}">
+          <a href="{{ charm.name }}{% if channel_requested %}?channel={{channel_requested}}{% endif %}" class="p-side-navigation__link u-truncate{% if subpackage_path == charm.name %} is-active{% endif %}" role="tab" aria-controls="{{ charm.name }}" aria-selected="{% if subpackage.name == charm.name %}true{% else %}false{% endif %}">
             <img class="p-side-navigation__icon" src="/{{ charm.name }}/icon" alt="{{ charm.name }}" width="16" height="16">
             {{ charm.title }}
           </a>

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -372,9 +372,10 @@ def details_configuration(entity_name, path=None):
 
         if not path and bundle_charms:
             default_charm = bundle_charms[0]
-            return redirect(
-                f"/{entity_name}/configure/{default_charm['name']}"
-            )
+            redirect_url = f"/{entity_name}/configure/{default_charm['name']}"
+            if channel_request:
+                redirect_url = redirect_url + f"?channel={channel_request}"
+            return redirect(redirect_url)
 
         if path:
             if not any(d["name"] == path for d in bundle_charms):
@@ -552,6 +553,7 @@ def details_integrations(entity_name):
     return render_template(
         "details/integrations.html",
         package=package,
+        channel_requested=channel_request,
     )
 
 


### PR DESCRIPTION
## Done
- Ensure channel parameter is persisted across all navigation

## How to QA
- Visit https://charmhub-io-1680.demos.haus/mlflow-server/resources/oci-image?channel=edge
- Visit https://charmhub-io-1680.demos.haus/kubeflow?channel=edge
- Ensure clicking navigation works as expected

## Issue / Card
Fixes https://github.com/canonical/charmhub.io/issues/1641
Fixes https://github.com/canonical/charmhub.io/issues/1539

## Screenshots
