### PR TITLE
Update charmhub.io navigation to match Juju.is navigation

### DIFF
--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -19,86 +19,42 @@
     <nav class="p-navigation__nav">
       <ul class="p-navigation__items">
         <li class="p-navigation__item{% if request.path == '/' %} is-selected{% endif %}">
-          <a class="p-navigation__link" href="https://charmhub.io">Charmhub</a>
+          <a class="p-navigation__link" href="/">Charmhub</a>
         </li>
-        <li class="p-navigation__item">
-          <a class="p-navigation__link" href="https://juju.is/about">About</a>
-        </li>
-        <li class="p-navigation__item--dropdown-toggle" id="learn-link">
-          <a class="p-navigation__link" href="#learn-link-menu" aria-controls="learn-link-menu">Learn</a>
-          <ul class="p-navigation__dropdown" id="learn-link-menu" aria-hidden="true">
+        <li class="p-navigation__item--dropdown-toggle" id="community-link">
+          <a class="p-navigation__link" href="#community-link-menu" aria-controls="community-link-menu">Community</a>
+          <ul class="p-navigation__dropdown" id="community-link-menu" aria-hidden="true">
             <li>
-              <a href="https://juju.is/docs" class="p-navigation__dropdown-item">
-              Documentation
+              <a href="https://discourse.charmhub.io" class="p-navigation__dropdown-item">
+                Discourse forum
               </a>
-              <ul class="p-navigation__sub-list u-no-margin--left u-no-padding--left">
-                <li>
-                  <a class="p-navigation__dropdown-item" href="https://juju.is/docs/juju">Juju docs: Manage charms</a>
-                </li>
-                <li>
-                  <a class="p-navigation__dropdown-item" href="https://juju.is/docs/sdk">SDK docs: Build charms</a>
-                </li>
-                <li>
-                  <a class="p-navigation__dropdown-item" href="https://juju.is/docs/dev">Dev docs: Contribute to Juju</a>
-                </li>
-                {#<li>
-                  <a class="p-navigation__dropdown-item" href="https://charmhub.io/interfaces">Interfaces</a>
-                </li>
-                <li>
-                  <a class="p-navigation__dropdown-item" href="https://juju.is/tutorials">Tutorials</a>
-                </li>#}
-              </ul>
             </li>
             <li>
-              <a class="p-navigation__dropdown-item" href="https://juju.is/cloud-native-kubernetes-usage-report-2022">Kubernetes & Cloud Native Operations Report</a>
+              <a href="https://chat.charmhub.io/" class="p-navigation__dropdown-item">
+                Mattermost chat
+              </a>
+            </li>
+          </ul>
+        </li>
+        <li class="p-navigation__item--dropdown-toggle" id="docs-link">
+          <a class="p-navigation__link" href="#docs-link-menu" aria-controls="docs-link-menu">Docs</a>
+          <ul class="p-navigation__dropdown" id="docs-link-menu" aria-hidden="true">
+            <li>
+              <a class="p-navigation__dropdown-item" href="https://juju.is/docs/juju">Juju</a>
+            </li>
+            <li>
+              <a class="p-navigation__dropdown-item" href="https://juju.is/docs/sdk">Charm SDK</a>
+            </li>
+            <li>
+              <a class="p-navigation__dropdown-item" href="https://juju.is/docs/dev">Contribute to Juju</a>
             </li>
             <li>
               <a class="p-navigation__dropdown-item" href="https://juju.is/operator-day">Operator Day</a>
             </li>
-            <li>
-              <a class="p-navigation__dropdown-item" href="https://juju.is/blog">Blog</a>
-            </li>
-            <li>
-              <a class="p-navigation__dropdown-item" href="https://charmhub.io/topics">Topics</a>
-            </li>
           </ul>
         </li>
-        <li class="p-navigation__item--dropdown-toggle" id="contribute-link">
-          <a class="p-navigation__link" href="#contribute-link-menu" aria-controls="contribute-link-menu">Contribute</a>
-          <ul class="p-navigation__dropdown" id="contribute-link-menu" aria-hidden="true">
-            <li>
-              <div class="p-navigation__dropdown-item is-title">
-                <div class="p-muted-heading u-no-margin--bottom">
-                  Create a charm
-                </div>
-              </div>
-            </li>
-            <li>
-              <a class="p-navigation__dropdown-item" href="https://juju.is/docs/sdk/set-up-a-charm-project">Build</a>
-            </li>
-            <li>
-              <a class="p-navigation__dropdown-item" href="https://juju.is/docs/sdk/publishing">Publish</a>
-            </li>
-            <li>
-              <div class="p-navigation__dropdown-item is-title">
-                <div class="p-muted-heading u-no-margin--bottom">
-                  Join the community
-                </div>
-              </div>
-            </li>
-            <li>
-              <a class="p-navigation__dropdown-item" href="https://discourse.charmhub.io/">Forum</a>
-            </li>
-            <li>
-              <a class="p-navigation__dropdown-item" href="https://chat.charmhub.io/charmhub/channels/juju">Chat</a>
-            </li>
-            <li>
-              <a class="p-navigation__dropdown-item" href="https://bugs.launchpad.net/juju">Report a bug</a>
-            </li>
-            <li>
-              <a class="p-navigation__dropdown-item" href="https://juju.is/careers">Careers</a>
-            </li>
-          </ul>
+        <li class="p-navigation__item">
+          <a class="p-navigation__link" href="https://ubuntu.com/blog/tag/juju">Blog</a>
         </li>
       </ul>
       <ul class="p-navigation__items global-nav">


### PR DESCRIPTION
## Done
Changed charmhub.io main navigation to match juju.is

## How to QA
- Visit https://charmhub-io-1681.demos.haus/, compare to https://juju.is navigation
- Make sure all the links work

## Issue / Card
Fixes https://github.com/canonical/charmhub.io/issues/1659

## Screenshots
