### PR TITLE
Add button to de-register charms and bundles

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -508,3 +508,11 @@ h3 {
 .u-split--3 {
   columns: 3;
 }
+
+// Vanilla top aligns table cells which causes misalignment when a button is
+// present. This table is targeted to avoid potential issues with other
+// existing tables.
+// stylelint-disable
+.registered-charms-table td {
+  vertical-align: middle;
+}

--- a/templates/publisher/list.html
+++ b/templates/publisher/list.html
@@ -154,7 +154,15 @@
           </div>
         </div>
         <div class="u-fixed-width">
-          <table aria-label="Registered charm names">
+          <div class="p-notification--negative is-inline u-hide" data-js="unregister-error">
+            <div class="p-notification__content">
+              <h5 class="p-notification__title">Error:</h5>
+              <p class="p-notification__message" data-js="unregister-error-message"></p>
+            </div>
+          </div>
+        </div>
+        <div class="u-fixed-width">
+          <table class="registered-charms-table" aria-label="Registered charm names">
             <thead>
               <tr role="row">
                 <th style="width: 30%;">
@@ -163,6 +171,7 @@
                 <th>
                   Visibility
                 </th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -177,6 +186,9 @@
                   {% else %}
                     Public
                   {% endif %}
+                </td>
+                <td class="u-align--right">
+                  <button class="p-button--base u-no-margin--bottom" data-js="unregister-button" data-package-name="{{ registered_charm['name'] }}">Unregister</button>
                 </td>
               </tr>
               {% endfor %}
@@ -258,6 +270,36 @@
 <script>
   window.addEventListener("DOMContentLoaded", function () {
     charmhub.publisher.list.init();
+  });
+
+  // De-register charms and bundles
+  const unregisterError = document.querySelector("[data-js='unregister-error']");
+  const unregisterErrorMessage = document.querySelector("[data-js='unregister-error-message']");
+  const unregisterButtons = document.querySelectorAll("[data-js='unregister-button']");
+  
+  unregisterButtons.forEach((unregisterButton) => {
+    unregisterButton.addEventListener("click", async () => {
+      unregisterError.classList.add("u-hide");
+      unregisterErrorMessage.innerText = "";
+
+      const packageName = unregisterButton.dataset.packageName;
+      const formData = new FormData();
+
+      formData.set("csrf_token", "{{ csrf_token() }}");
+      
+      const response = await fetch(`/${packageName}`, {
+        method: "DELETE",
+        body: formData,
+      });
+      
+      if (response.status === 200) {
+        window.location.reload();
+      } else {
+        const responseData = await response.json();
+        unregisterErrorMessage.innerText = responseData.error;
+        unregisterError.classList.remove("u-hide");
+      }
+    });
   });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Done
Added a button to un-register charms and bundles

## How to QA
- Go to https://charmhub-io-1685.demos.haus/charms
- Check that you can un-register a charm from the "Registered charms" table (you may need to register one first)
- Go to https://charmhub-io-1685.demos.haus/bundles
- Check that you can un-register a bundle from the "Registered bundles" table (you may need to register one first)

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-6600