### PR TITLE
Update unregister modal text

### DIFF
--- a/templates/publisher/list.html
+++ b/templates/publisher/list.html
@@ -203,7 +203,7 @@
             <h2 class="p-modal__title"><i class="p-icon--warning modal-header-icon"></i> Unregister “<span data-js="package-name"></span>”</h2>
             <button class="p-modal__close" data-js="close-confirmation-modal-button">Close</button>
           </header>
-          <p>Are you sure you want to unregister “<span data-js="package-name"></span>”? This action is permanent and cannot be undone.</p>
+          <p>Are you sure you want to unregister “<span data-js="package-name"></span>”? This name will be removed from your registered names and become available to others.</p>
           <footer class="p-modal__footer">
             <button class="u-no-margin--bottom" aria-controls="modal" data-js="close-confirmation-modal-button">Cancel</button>
             <button class="p-button--negative u-no-margin--bottom" data-js="unregister-package-button">Unregister</button>


### PR DESCRIPTION
## Done
Updated the copy on the unregister modal

## How to QA
- Go to https://charmhub-io-1687.demos.haus/charms
- Register a charm if you don't have one already
- Click the "Unregister" button
- Check that the copy matches:
> Are you sure you want to unregister "name"? This name will be removed from your registered names and become available to others.

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-6770