### PR TITLE
Bump canonicalwebteam.discourse to 5.4.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 canonicalwebteam.flask-base==1.1.0
 beautifulsoup4==4.11.1
 canonicalwebteam.candid==0.9.0
-canonicalwebteam.discourse==5.4.2
+canonicalwebteam.discourse==5.4.3
 canonicalwebteam.image-template==1.3.1
 canonicalwebteam.store-api==4.6.0
 canonicalwebteam.docstring-extractor==1.2.0


### PR DESCRIPTION
## Done

Bump canonicalwebteam.discourse to 5.4.3

## How to QA

- Browse the discourse powered sections in the demo environment and check they work.