### PR TITLE
Update charm icon validator to include a preview.

### DIFF
--- a/templates/details/_details-header.html
+++ b/templates/details/_details-header.html
@@ -5,16 +5,15 @@
   <div class="row">
     <div class="col-8">
       <div class="p-charm-header">
-        <div class="p-media-object--medium u-no-margin--bottom">
+        <div class="p-media-object--large">
           {% if package.type == "charm" %}
-          <div class="p-media-object__image-container">
             {% if package["store_front"]["icons"] %}
               {{
                 image(
                   url=package.store_front.icons[0],
                   alt=package.name,
-                  width="64",
-                  height="64",
+                  width="100",
+                  height="100",
                   hi_def=True,
                   fill=True,
                   attrs={"class": "p-media-object__image"},
@@ -25,15 +24,14 @@
                 image(
                   url="https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg",
                   alt=package.name,
-                  width="60",
-                  height="60",
+                  width="100",
+                  height="100",
                   hi_def=True,
                   fill=True,
                   attrs={"class": "p-media-object__image"},
                 ) | safe
               }}
             {% endif %}
-          </div>
           {% endif %}
           <div class="p-media-object__details">
             <h1 class="p-media-object__title">

--- a/templates/icon-validator.html
+++ b/templates/icon-validator.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>Charm icon validator</title>
-    <link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-3.7.1.min.css" />
+    <link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-4.5.0.min.css" />
 
     <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':


### PR DESCRIPTION
## Done
- Updated icon-validator to show a rough preview
- Updated the header for charm details... we'll see

## How to QA
- Go to https://charmhub-io-1700.demos.haus/icon-validator and upload a valid svg (https://raw.githubusercontent.com/dwellir-public/polkadot-operator/main/icon.svg) for example – see the preview
- Go to https://charmhub-io-1700.demos.haus/ and click on a charm, make sure the header looks ok

## Issue / Card
Fixes #

## Screenshots
![image](https://github.com/canonical/charmhub.io/assets/479384/3caced4a-d55f-4008-9e23-627944b259df)
