### PR TITLE
Fix duplicate platforms showing on charms

### DIFF
--- a/templates/details/_details-header.html
+++ b/templates/details/_details-header.html
@@ -87,7 +87,7 @@
         {% for track, track_data in package.store_front.channel_map.items() %}
           {% for channel, channel_data in track_data.items() %}
             {% for base in package.store_front.all_channel_bases %}
-              {% if track == package["default-release"].channel.track and channel == package["default-release"].channel.risk %}
+              {% if track == package["default-release"].channel.track and channel == package["default-release"].channel.risk and loop.index == 1 %}
                 <div class="series-base">
                   <div class="series-base__title">
                     {% if base["name"] == "ubuntu" %}

--- a/templates/partial/_channel-map.html
+++ b/templates/partial/_channel-map.html
@@ -45,7 +45,7 @@
                 <td data-heading="Runs on">
                   <div class="series-tags u-no-margin--top">
                     {% for channel_base in package.store_front.all_channel_bases %}
-                    {% if channel_data.latest.risk == channel %}
+                    {% if channel_data.latest.risk == channel and loop.index == 1 %}
                     {% for base in channel_data.latest.bases %}
                       <span class="series-tag">{{ base }}</span>
                       {% endfor %}


### PR DESCRIPTION
## Done
Fixed issue with duplicate platforms showing on some charms

## How to QA
- Go to https://charmhub-io-1705.demos.haus/ovn-chassis
- Check that there is only one platform
- Go to https://charmhub-io-1705.demos.haus/cos-proxy
- Check that there is only one platform