### PR TITLE
Fix display of bundle charms

### DIFF
--- a/templates/details/overview.html
+++ b/templates/details/overview.html
@@ -12,7 +12,7 @@
         <h2 class="p-heading--4">Charms in the {{ package.store_front["display-name"] }} bundle</h2>
         <div class="row p-bundle-icons">
           {% for charm in package['store_front']['bundle']['charms'] %}
-            <div class="col-3 col-medium-3">
+            <div class="col-3 col-medium-6">
               {% include "/details/_bundle_icon.html" %}
             </div>
           {% endfor %}


### PR DESCRIPTION
## Done
Fixed the display of the charms in bundles

## How to QA
- Go to https://charmhub-io-1716.demos.haus/kubeflow
- Check that the "Charms in bundle" icons don't look broken on medium screen sizes

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-7654
Fixes #1715 1715