### PR TITLE
fix: update mattermost link to matrix

### DIFF
--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -30,8 +30,8 @@
               </a>
             </li>
             <li>
-              <a href="https://chat.charmhub.io/" class="p-navigation__dropdown-item">
-                Mattermost chat
+              <a href="https://matrix.to/#/#charmhub:ubuntu.com" class="p-navigation__dropdown-item">
+                Matrix chat
               </a>
             </li>
           </ul>


### PR DESCRIPTION
## Done
- Update navigation from a Mattermost link to Matrix

## QA
- Visit the demo
- Check the "Community" navigation dropdown has a link to matrix.