### PR TITLE
Reset pagination on search

### DIFF
--- a/static/js/store/components/Banner/Banner.tsx
+++ b/static/js/store/components/Banner/Banner.tsx
@@ -21,6 +21,7 @@ function Banner({ searchRef, searchSummaryRef }: Props) {
               e.preventDefault();
 
               if (searchRef.current && searchRef.current.value) {
+                searchParams.delete("page");
                 searchParams.set("q", searchRef.current.value);
                 setSearchParams(searchParams);
               }


### PR DESCRIPTION
## Done
Reset the pagination on search

## How to QA
- Go to https://charmhub-io-1731.demos.haus/
- Use the pagination to go to page 4
- Search for "logging"
- Check that the `page` query parameter has been removed
- Check that the results count above the search results is correct

## Issue / Card
Fixes #1726
Fixes https://warthogs.atlassian.net/browse/WD-8112