### PR TITLE
Prevent duplicate invites from being created

### DIFF
--- a/static/js/src/publisher/collaborator/components/Collaborators.tsx
+++ b/static/js/src/publisher/collaborator/components/Collaborators.tsx
@@ -21,6 +21,8 @@ import {
 } from "../hooks";
 import { inviteToRevokeState } from "../atoms";
 
+import type { Invite } from "../types";
+
 declare global {
   interface Window {
     CSRF_TOKEN: string;
@@ -64,6 +66,26 @@ function Collaborators() {
     setShowRevokeSuccess,
     setShowRevokeError
   );
+
+  const isUnique = (newCollaboratorEmail: string | undefined) => {
+    if (!newCollaboratorEmail) {
+      return true;
+    }
+
+    if (!invites) {
+      return false;
+    }
+
+    const existingInvites = invites.filter(
+      (invite: Invite) => invite.email === newCollaboratorEmail
+    );
+
+    if (!existingInvites.length) {
+      return true;
+    }
+
+    return false;
+  };
 
   return (
     <div className="l-application collaboration-ui">
@@ -183,10 +205,21 @@ function Collaborators() {
                 ) => {
                   setNewCollaboratorEmail(e.target.value);
                 }}
+                error={
+                  !isUnique(newCollaboratorEmail)
+                    ? "There is already an invite for this email address"
+                    : ""
+                }
               />
             </div>
             <div className="panel__footer">
-              <Button type="submit" appearance="positive">
+              <Button
+                type="submit"
+                appearance="positive"
+                disabled={
+                  !newCollaboratorEmail || !isUnique(newCollaboratorEmail)
+                }
+              >
                 Add collaborator
               </Button>
             </div>


### PR DESCRIPTION
## Done
Prevented duplicate invites from being created

## How to QA
- Go to https://charmhub-io-1740.demos.haus/<CHARM_NAME>/collaboration
- Click "Add new collaborator"
- Check that the "Add collaborator" button is disabled
- Enter a value into the input
- Check that the button is now enabled
- Enter an email address that there is already an invite for
- Check that the button is disabled and that there is an error message

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-8296