### PR TITLE
Add confirmation modals for resending and reopening invites

### DIFF
--- a/static/js/src/publisher/collaborator/atoms/index.ts
+++ b/static/js/src/publisher/collaborator/atoms/index.ts
@@ -1,8 +1,18 @@
 import { atom } from "recoil";
 
-const inviteToRevokeState = atom({
-  key: "inviteToRevoke",
+const activeInviteState = atom({
+  key: "activeInvite",
   default: "",
 });
 
-export { inviteToRevokeState };
+const actionState = atom({
+  key: "action",
+  default: "",
+});
+
+const inviteLinkState = atom({
+  key: "inviteLink",
+  default: "",
+});
+
+export { activeInviteState, actionState, inviteLinkState };

--- a/static/js/src/publisher/collaborator/components/App.tsx
+++ b/static/js/src/publisher/collaborator/components/App.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
-import { QueryClient, QueryClientProvider, useQuery } from "react-query";
+import { QueryClient, QueryClientProvider } from "react-query";
 import { RecoilRoot } from "recoil";
 
 import Collaborators from "./Collaborators";

--- a/static/js/src/publisher/collaborator/components/Collaborators.tsx
+++ b/static/js/src/publisher/collaborator/components/Collaborators.tsx
@@ -1,7 +1,7 @@
 import React, { useState, SyntheticEvent } from "react";
 import { useParams } from "react-router-dom";
 import { useQueryClient } from "react-query";
-import { useRecoilValue } from "recoil";
+import { useRecoilValue, useRecoilState } from "recoil";
 import {
   Accordion,
   Strip,
@@ -23,7 +23,7 @@ import {
   useSendInviteMutation,
   useRevokeInviteMutation,
 } from "../hooks";
-import { inviteToRevokeState } from "../atoms";
+import { activeInviteState, actionState, inviteLinkState } from "../atoms";
 
 import type { Invite } from "../types";
 
@@ -36,17 +36,14 @@ declare global {
 function Collaborators() {
   const { packageName } = useParams();
   const queryClient = useQueryClient();
-  const inviteToRevoke = useRecoilValue(inviteToRevokeState);
-  const [showRevokeConfirmation, setShowRevokeConfirmation] = useState(false);
+  const [activeInvite, setActiveInvite] = useRecoilState(activeInviteState);
+  const [inviteLink, setInviteLink] = useRecoilState(inviteLinkState);
+  const action = useRecoilValue(actionState);
+  const [showConfirmation, setShowConfirmation] = useState(false);
+  const [showInviteSuccess, setShowInviteSuccess] = useState(false);
   const [showRevokeSuccess, setShowRevokeSuccess] = useState(false);
   const [showRevokeError, setShowRevokeError] = useState(false);
-  const [newCollaboratorEmail, setNewCollaboratorEmail] = useState("");
-  const [inviteLink, setInviteLink] = useState("");
   const [showAddCollaborator, setShowAddCollaborator] = useState(false);
-
-  const closeRevokeConfirmation = () => {
-    setShowRevokeConfirmation(false);
-  };
 
   const {
     isLoading: collaboratorsIsLoading,
@@ -62,23 +59,25 @@ function Collaborators() {
 
   const sendInviteMutation = useSendInviteMutation(
     packageName,
-    newCollaboratorEmail,
     window.CSRF_TOKEN,
     queryClient,
-    setInviteLink
+    activeInvite,
+    setInviteLink,
+    setShowInviteSuccess,
+    setShowAddCollaborator
   );
 
   const revokeInviteMutation = useRevokeInviteMutation(
     packageName,
     window.CSRF_TOKEN,
     queryClient,
-    inviteToRevoke,
+    activeInvite,
     setShowRevokeSuccess,
     setShowRevokeError
   );
 
-  const isUnique = (newCollaboratorEmail: string | undefined) => {
-    if (!newCollaboratorEmail) {
+  const isUnique = (activeInvite: string | undefined) => {
+    if (!activeInvite) {
       return true;
     }
 
@@ -87,7 +86,7 @@ function Collaborators() {
     }
 
     const existingInvites = invites.filter((invite: Invite) => {
-      return invite.email === newCollaboratorEmail && isPending(invite);
+      return invite.email === activeInvite && isPending(invite);
     });
 
     if (!existingInvites.length) {
@@ -101,6 +100,18 @@ function Collaborators() {
     <div className="l-application collaboration-ui">
       <div className="l-main">
         <Strip shallow>
+          {showInviteSuccess && (
+            <Notification
+              severity="positive"
+              onDismiss={() => {
+                setShowInviteSuccess(false);
+              }}
+            >
+              An invite has been created. <a href={inviteLink}>Accept invite</a>
+              .
+            </Notification>
+          )}
+
           {showRevokeSuccess && (
             <Notification
               severity="positive"
@@ -108,7 +119,7 @@ function Collaborators() {
                 setShowRevokeSuccess(false);
               }}
             >
-              The invite for <strong>{inviteToRevoke}</strong> has been revoked.
+              The invite for <strong>{activeInvite}</strong> has been revoked.
             </Notification>
           )}
 
@@ -120,7 +131,7 @@ function Collaborators() {
               }}
             >
               There was a problem revoking the invite for{" "}
-              <strong>{inviteToRevoke}</strong>.
+              <strong>{activeInvite}</strong>.
             </Notification>
           )}
 
@@ -169,9 +180,7 @@ function Collaborators() {
                       invites.length > 0 && (
                         <InvitesTable
                           invites={invites}
-                          setShowRevokeConfirmation={setShowRevokeConfirmation}
-                          inviteCollaborator={() => false}
-                          setInviteLink={setInviteLink}
+                          setShowConfirmation={setShowConfirmation}
                         />
                       )}
                   </>
@@ -193,8 +202,8 @@ function Collaborators() {
           style={{ height: "100%" }}
           onSubmit={(e) => {
             e.preventDefault();
-            sendInviteMutation.mutate(newCollaboratorEmail);
-            setNewCollaboratorEmail("");
+            sendInviteMutation.mutate(activeInvite);
+            setActiveInvite("");
           }}
         >
           <div className="panel">
@@ -215,28 +224,22 @@ function Collaborators() {
                 A collaborator is a store user that can have equal rights over a
                 particular package as the package publisher.
               </Notification>
-              {inviteLink && (
-                <Notification severity="positive">
-                  An invite has been created.{" "}
-                  <a href={inviteLink}>Accept invite</a>.
-                </Notification>
-              )}
               <Input
                 type="email"
                 id="collaborator-email"
                 label="Email"
                 placeholder="yourname@example.com"
                 help="The primary email for the Ubuntu One account"
-                value={newCollaboratorEmail}
+                value={activeInvite}
                 onInput={(
                   e: SyntheticEvent<HTMLInputElement> & {
                     target: HTMLInputElement;
                   }
                 ) => {
-                  setNewCollaboratorEmail(e.target.value);
+                  setActiveInvite(e.target.value);
                 }}
                 error={
-                  !isUnique(newCollaboratorEmail)
+                  !isUnique(activeInvite)
                     ? "There is already an invite for this email address"
                     : ""
                 }
@@ -256,9 +259,7 @@ function Collaborators() {
                 type="submit"
                 appearance="positive"
                 className="u-no-margin--bottom"
-                disabled={
-                  !newCollaboratorEmail || !isUnique(newCollaboratorEmail)
-                }
+                disabled={!activeInvite || !isUnique(activeInvite)}
               >
                 Add collaborator
               </Button>
@@ -267,16 +268,20 @@ function Collaborators() {
         </Form>
       </aside>
 
-      {showRevokeConfirmation && (
+      {showConfirmation && (
         <Modal
-          close={closeRevokeConfirmation}
-          title="Revoke invite"
+          close={() => {
+            setShowConfirmation(false);
+          }}
+          title={`${action} invite`}
           buttonRow={
             <>
               <Button
                 type="button"
                 className="u-no-margin--bottom"
-                onClick={closeRevokeConfirmation}
+                onClick={() => {
+                  setShowConfirmation(false);
+                }}
               >
                 Cancel
               </Button>
@@ -284,18 +289,25 @@ function Collaborators() {
                 appearance="positive"
                 className="u-no-margin--bottom"
                 onClick={() => {
-                  revokeInviteMutation.mutate(inviteToRevoke);
-                  setShowRevokeConfirmation(false);
+                  if (action === "Revoke") {
+                    revokeInviteMutation.mutate(activeInvite);
+                  }
+
+                  if (action === "Resend" || action === "Reopen") {
+                    sendInviteMutation.mutate(activeInvite);
+                  }
+
+                  setShowConfirmation(false);
                 }}
               >
-                Revoke invite
+                {action} invite
               </Button>
             </>
           }
         >
           <p>
-            Are you sure you want to revoke the invite for{" "}
-            <strong>{inviteToRevoke}</strong>?
+            Are you sure you want to {action.toLowerCase()} the invite for{" "}
+            <strong>{activeInvite}</strong>?
           </p>
         </Modal>
       )}

--- a/static/js/src/publisher/collaborator/components/InvitesTable.tsx
+++ b/static/js/src/publisher/collaborator/components/InvitesTable.tsx
@@ -1,11 +1,8 @@
 import React from "react";
-import { useParams } from "react-router-dom";
 import { MainTable } from "@canonical/react-components";
-import { useQueryClient } from "react-query";
-import { useRecoilState } from "recoil";
+import { useSetRecoilState } from "recoil";
 
-import { useSendInviteMutation } from "../hooks";
-import { inviteToRevokeState } from "../atoms";
+import { activeInviteState, actionState } from "../atoms";
 
 import {
   buildInviteTableRows,
@@ -18,29 +15,12 @@ import type { Invite } from "../types";
 
 type Props = {
   invites: Array<Invite>;
-  setShowRevokeConfirmation: Function;
-  inviteCollaborator: Function;
-  setInviteLink: Function;
+  setShowConfirmation: Function;
 };
 
-function InvitesTable({
-  invites,
-  setShowRevokeConfirmation,
-  setInviteLink,
-}: Props) {
-  const { packageName } = useParams();
-  const queryClient = useQueryClient();
-
-  const [inviteToRevoke, setInviteToRevoke] =
-    useRecoilState(inviteToRevokeState);
-
-  const sendInviteMutation = useSendInviteMutation(
-    packageName,
-    inviteToRevoke,
-    window.CSRF_TOKEN,
-    queryClient,
-    setInviteLink
-  );
+function InvitesTable({ invites, setShowConfirmation }: Props) {
+  const setActiveInvite = useSetRecoilState(activeInviteState);
+  const setAction = useSetRecoilState(actionState);
 
   const pendingInvites = invites.filter((invite) => {
     return !isAccepted(invite) && !isRevoked(invite) && !isExpired(invite);
@@ -57,25 +37,25 @@ function InvitesTable({
   const pendingInviteRows = buildInviteTableRows(
     pendingInvites,
     "Pending",
-    setShowRevokeConfirmation,
-    setInviteToRevoke,
-    sendInviteMutation
+    setShowConfirmation,
+    setActiveInvite,
+    setAction
   );
 
   const expiredInviteRows = buildInviteTableRows(
     expiredInvites,
     "Expired",
-    setShowRevokeConfirmation,
-    setInviteToRevoke,
-    sendInviteMutation
+    setShowConfirmation,
+    setActiveInvite,
+    setAction
   );
 
   const revokedInviteRows = buildInviteTableRows(
     revokedInvites,
     "Revoked",
-    setShowRevokeConfirmation,
-    setInviteToRevoke,
-    sendInviteMutation
+    setShowConfirmation,
+    setActiveInvite,
+    setAction
   );
 
   return (

--- a/static/js/src/publisher/collaborator/hooks/index.ts
+++ b/static/js/src/publisher/collaborator/hooks/index.ts
@@ -45,16 +45,18 @@ export function useInvitesQuery(packageName: string | undefined) {
 
 export function useSendInviteMutation(
   packageName: string | undefined,
-  newCollaboratorEmail: string,
   csrfToken: string,
   queryClient: any,
-  setInviteLink: Function
+  inviteToSend: string,
+  setInviteLink: Function,
+  setShowInviteSuccess: Function,
+  setShowAddCollaborator: Function
 ) {
   return useMutation(
     async () => {
       const formData = new FormData();
 
-      formData.set("collaborators", newCollaboratorEmail);
+      formData.set("collaborators", inviteToSend);
       formData.set("csrf_token", csrfToken);
 
       const response = await fetch(`/${packageName}/invite`, {
@@ -72,6 +74,9 @@ export function useSendInviteMutation(
       setInviteLink(
         `/accept-invite?package=${packageName}&token=${inviteData.data[0].token}`
       );
+
+      setShowInviteSuccess(true);
+      setShowAddCollaborator(false);
     },
     {
       onMutate: async (inviteEmail: string) => {

--- a/static/js/src/publisher/collaborator/utils.tsx
+++ b/static/js/src/publisher/collaborator/utils.tsx
@@ -7,9 +7,9 @@ import type { Invite } from "./types";
 function buildInviteTableRows(
   invites: Array<Invite>,
   status: "Pending" | "Expired" | "Revoked",
-  setShowRevokeConfirmation: Function,
-  setInviteToRevoke: Function,
-  sendInviteMutation: any
+  setShowConfirmation: Function,
+  setActiveInvite: Function,
+  setAction: Function
 ) {
   return invites.map((invite: Invite, index) => {
     let columns: any[] = [];
@@ -52,8 +52,9 @@ function buildInviteTableRows(
                   type="button"
                   dense
                   onClick={() => {
-                    setShowRevokeConfirmation(true);
-                    setInviteToRevoke(invite.email);
+                    setAction("Revoke");
+                    setShowConfirmation(true);
+                    setActiveInvite(invite.email);
                   }}
                 >
                   Revoke
@@ -62,8 +63,9 @@ function buildInviteTableRows(
                   type="button"
                   dense
                   onClick={() => {
-                    setInviteToRevoke(invite.email);
-                    sendInviteMutation.mutate(invite.email);
+                    setAction("Resend");
+                    setShowConfirmation(true);
+                    setActiveInvite(invite.email);
                   }}
                 >
                   Resend
@@ -75,8 +77,9 @@ function buildInviteTableRows(
                 type="button"
                 dense
                 onClick={() => {
-                  setInviteToRevoke(invite.email);
-                  sendInviteMutation.mutate(invite.email);
+                  setAction("Reopen");
+                  setShowConfirmation(true);
+                  setActiveInvite(invite.email);
                 }}
               >
                 Reopen
@@ -87,8 +90,9 @@ function buildInviteTableRows(
                 type="button"
                 dense
                 onClick={() => {
-                  setInviteToRevoke(invite.email);
-                  sendInviteMutation.mutate(invite.email);
+                  setAction("Reopen");
+                  setShowConfirmation(true);
+                  setActiveInvite(invite.email);
                 }}
               >
                 Reopen


### PR DESCRIPTION
## Done
- Added confirmation modals for resending and reopening invites
- Added success notification with invite link when resending and reopening invites

## How to QA
- Go to https://charmhub-io-1752.demos.haus/<CHARM_NAME>/collaboration
- Click on "Resend" for an invite
- Check that a confirmation modal appears
- Click on "Resend invite"
- Check that a notification appears with an "Accept invite" link
- Click on "Reopen" for an invite
- Check that a confirmation modal appears
- Click on "Reopen invite"
- Check that a notification appears with an "Accept invite" link

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-8574