### PR TITLE
feat: persist redirect params after logins

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Install python dependencies
         run: |
           python3 -m pip install --upgrade pip
-          sudo pip3 install flake8 black
+          sudo pip3 install -r requirements.txt
 
       - name: Lint python
         run: yarn lint-python

--- a/tests/test_param_redirect.py
+++ b/tests/test_param_redirect.py
@@ -1,0 +1,209 @@
+import unittest
+from unittest.mock import MagicMock
+import json
+from datetime import datetime, timedelta
+
+from webapp.helpers import param_redirect_capture, param_redirect_exec
+
+
+class MockCookies:
+    def __init__(self, cookie={}):
+        self.cookie = cookie
+
+    def set_cookie(self, name, data, expires):
+        self.cookie[name] = {"data": data, "expires": expires}
+
+    def get(self, name):
+        return self.cookie[name]
+
+
+class MockRequest:
+    def __init__(self, path, args, cookies: MockCookies):
+        self.path = path
+        self.args = args
+        self.cookies = cookies if cookies else MockCookies()
+
+
+class TestParamRedirect(unittest.TestCase):
+    def setUp(self):
+        self.cookies = MockCookies()
+
+    def test_param_redirect_capture_matches(self):
+        """
+        Test param capture works when the signature is exactly the same
+        """
+        req = MockRequest(
+            path="/accept-invite",
+            args={"package": "test", "token": "test"},
+            cookies=self.cookies,
+        )
+
+        resp = req.cookies
+
+        param_redirect_capture(req, resp)
+
+        self.assertEqual(
+            self.cookies.get("param_redirect")["data"],
+            json.dumps(
+                {
+                    "endpoint": "/accept-invite",
+                    "params": {"package": "test", "token": "test"},
+                }
+            ),
+        )
+
+        self.assertLess(
+            self.cookies.get("param_redirect")["expires"],
+            datetime.now() + timedelta(days=10),
+        )
+
+    def test_param_redirect_capture_matches_order(self):
+        """
+        Test param capture works when args are in a different order
+        """
+        req = MockRequest(
+            path="/accept-invite",
+            args={"token": "test", "package": "test"},
+            cookies=self.cookies,
+        )
+
+        resp = req.cookies
+
+        param_redirect_capture(req, resp)
+
+        self.assertEqual(
+            self.cookies.get("param_redirect")["data"],
+            json.dumps(
+                {
+                    "endpoint": "/accept-invite",
+                    "params": {"package": "test", "token": "test"},
+                }
+            ),
+        )
+
+        self.assertLess(
+            self.cookies.get("param_redirect")["expires"],
+            datetime.now() + timedelta(days=10),
+        )
+
+    def test_param_redirect_capture_matches_args(self):
+        """
+        Test param capture works when there are more arguments defined
+        """
+        req = MockRequest(
+            path="/accept-invite",
+            args={"package": "test", "token": "test", "test": "test"},
+            cookies=self.cookies,
+        )
+
+        resp = req.cookies
+
+        param_redirect_capture(req, resp)
+
+        self.assertEqual(
+            self.cookies.get("param_redirect")["data"],
+            json.dumps(
+                {
+                    "endpoint": "/accept-invite",
+                    "params": {"package": "test", "token": "test"},
+                }
+            ),
+        )
+
+        self.assertLess(
+            self.cookies.get("param_redirect")["expires"],
+            datetime.now() + timedelta(days=10),
+        )
+
+    def test_param_redirect_capture_does_not_match(self):
+        """
+        Test param capture doesn't capture a signature that doesn't match
+        """
+        req = MockRequest(
+            path="/accept-invite/test",
+            args={"package": "test", "token": "test"},
+            cookies=self.cookies,
+        )
+
+        resp = req.cookies
+
+        param_redirect_capture(req, resp)
+
+        self.assertNotIn("param_redirect", self.cookies.cookie)
+
+    def test_param_redirect_exec(self):
+        """
+        Tests successfuly retrieval of cookie and redirect
+        """
+        req = MockRequest(
+            path="/accept-invite",
+            args={"package": "test", "token": "test"},
+            cookies=MockCookies(
+                {
+                    "param_redirect": json.dumps(
+                        {
+                            "endpoint": "/accept-invite",
+                            "params": {"package": "test", "token": "test"},
+                        }
+                    )
+                }
+            ),
+        )
+        make_response = MagicMock()
+        redirect = MagicMock()
+        param_redirect_exec(
+            req=req, make_response=make_response, redirect=redirect
+        )
+
+        redirect.assert_called_with("/accept-invite?package=test&token=test")
+
+    def test_param_redirect_exec_no_match_path(self):
+        """
+        Tests successful continuation if the path doesn't match.
+        """
+        req = MockRequest(
+            path="/accept-invite/test",
+            args={"package": "test", "token": "test"},
+            cookies=MockCookies(
+                {
+                    "param_redirect": json.dumps(
+                        {
+                            "endpoint": "/accept-invite",
+                            "params": {"package": "test", "token": "test"},
+                        }
+                    )
+                }
+            ),
+        )
+        make_response = MagicMock()
+        redirect = MagicMock()
+        resp = param_redirect_exec(
+            req=req, make_response=make_response, redirect=redirect
+        )
+
+        self.assertIsNone(resp)
+
+        redirect.assert_not_called()
+
+    def test_param_redirect_exec_no_cookie(self):
+        """
+        Tests successful continuation if there is no cookie.
+        """
+        req = MockRequest(
+            path="/accept-invite",
+            args={"package": "test", "token": "test"},
+            cookies=MockCookies({"param_redirect": None}),
+        )
+        make_response = MagicMock()
+        redirect = MagicMock()
+        resp = param_redirect_exec(
+            req=req, make_response=make_response, redirect=redirect
+        )
+
+        self.assertIsNone(resp)
+
+        redirect.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/webapp/decorators.py
+++ b/webapp/decorators.py
@@ -6,6 +6,27 @@ from distutils.util import strtobool
 # Third party packages
 import flask
 from webapp import authentication
+from webapp.helpers import param_redirect_capture, param_redirect_exec
+
+
+def cached_redirect(func):
+    """
+    Decorator that check for a param_redirect cookie and redirects
+    to the appropriate URL.
+    """
+
+    @functools.wraps(func)
+    def param_redirect(*args, **kwargs):
+        resp = param_redirect_exec(
+            req=flask.request,
+            make_response=flask.make_response,
+            redirect=flask.redirect,
+        )
+        if resp:
+            return resp
+        return func(*args, **kwargs)
+
+    return param_redirect
 
 
 def login_required(func):
@@ -17,9 +38,18 @@ def login_required(func):
     @functools.wraps(func)
     def is_user_logged_in(*args, **kwargs):
         if not authentication.is_authenticated(flask.session):
+            response = None
             if "beta" in flask.request.url:
-                return flask.redirect("/login?next=/beta" + flask.request.path)
-            return flask.redirect("/login?next=" + flask.request.path)
+                response = flask.make_response(
+                    flask.redirect("/login?next=/beta" + flask.request.path)
+                )
+            response = flask.make_response(
+                flask.redirect("/login?next=" + flask.request.path)
+            )
+
+            response = param_redirect_capture(flask.request, response)
+
+            return response
 
         return func(*args, **kwargs)
 

--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -13,7 +13,7 @@ from flask import (
 )
 from flask.json import jsonify
 from webapp.config import DETAILS_VIEW_REGEX
-from webapp.decorators import login_required
+from webapp.decorators import login_required, cached_redirect
 from webapp.helpers import get_licenses
 
 publisher = Blueprint(
@@ -80,6 +80,7 @@ def collaboration(entity_name, path):
 
 @publisher.route("/accept-invite")
 @login_required
+@cached_redirect
 def accept_invite():
     return render_template("publisher/accept-invite.html")
 

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -693,10 +693,10 @@ def entity_embedded_card(entity_name):
     try:
         package = get_package(entity_name, channel_request, FIELDS)
 
-        package["default-release"]["channel"]["released-at"] = (
-            logic.convert_date(
-                package["default-release"]["channel"]["released-at"]
-            )
+        package["default-release"]["channel"][
+            "released-at"
+        ] = logic.convert_date(
+            package["default-release"]["channel"]["released-at"]
         )
 
         button = request.args.get("button")
@@ -736,10 +736,10 @@ def entity_embedded_interface_card(entity_name):
     try:
         package = get_package(entity_name, channel_request, FIELDS)
 
-        package["default-release"]["channel"]["released-at"] = (
-            logic.convert_date(
-                package["default-release"]["channel"]["released-at"]
-            )
+        package["default-release"]["channel"][
+            "released-at"
+        ] = logic.convert_date(
+            package["default-release"]["channel"]["released-at"]
         )
 
         libraries = logic.process_libraries(


### PR DESCRIPTION
## Done
- Added a two of functions for capturing parameters before login redirect and after
  - `param_redirect_capture` captures the state in a cookie if the URL signature matches. 
    - Sets cookie expiration to 10 days - this is conservative and we might consider reducing this as a default
  - `param_redirect_exec` pops the state out of the cookie (and removes the cookie) if the path matches.
- Added a call to `param_redirect_capture` from the `login_required` decorator
- Added a new decorator `cached_redirect` that calls `param_redirect_exec` and uses the current URL path to match a cookie

## How to QA
**With an invitation URL to a charm**
- In a private browser that you're not logged in:
  - Visit the URL
  - When redirected to login.ubuntu.com, open the demo in a different tab and confirm a `param_redirect` cookie has been created for the demo URL.
  - Go through login process
  - after login you should be redirected back to the original URL with parameters
  - The previously created cookie should also be removed

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-8484

## Screenshots
