### PR TITLE
feat: add "topics" back to docs navigation

### DIFF
--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -51,6 +51,9 @@
             <li>
               <a class="p-navigation__dropdown-item" href="https://juju.is/operator-day">Operator Day</a>
             </li>
+            <li>
+              <a class="p-navigation__dropdown-item" href="/topics">Topics</a>
+            </li>
           </ul>
         </li>
         <li class="p-navigation__item">


### PR DESCRIPTION
## Done

- Added "Topics" back to docs menu

## QA

- Visit the demo
- See "Topics" in the docs menu
- Topics should go to /topics


## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-8100
