### PR TITLE
Truncate a charm icon title displayed within the column

### DIFF
--- a/static/sass/_charmhub_p-bundle-icons.scss
+++ b/static/sass/_charmhub_p-bundle-icons.scss
@@ -35,7 +35,7 @@
       display: inline-block;
       font-size: 1rem;
       margin-left: 0.15rem;
-      max-width: calc(100% - $icon-size - 1.5rem);;
+      max-width: calc(100% - $icon-size - 0.5rem);;
       overflow: hidden;
       text-overflow: ellipsis;
       vertical-align: top;

--- a/static/sass/_charmhub_p-bundle-icons.scss
+++ b/static/sass/_charmhub_p-bundle-icons.scss
@@ -35,7 +35,7 @@
       display: inline-block;
       font-size: 1rem;
       margin-left: 0.15rem;
-      max-width: 10rem;
+      max-width: calc(100% - $icon-size - 1.5rem);;
       overflow: hidden;
       text-overflow: ellipsis;
       vertical-align: top;

--- a/static/sass/_charmhub_p-bundle-icons.scss
+++ b/static/sass/_charmhub_p-bundle-icons.scss
@@ -35,11 +35,11 @@
       display: inline-block;
       font-size: 1rem;
       margin-left: 0.15rem;
-      vertical-align: top;
       max-width: 10rem;
       overflow: hidden;
-      white-space: nowrap;
       text-overflow: ellipsis;
+      vertical-align: top;
+      white-space: nowrap;
     }
   }
 

--- a/static/sass/_charmhub_p-bundle-icons.scss
+++ b/static/sass/_charmhub_p-bundle-icons.scss
@@ -32,8 +32,14 @@
     }
 
     .p-bundle-icon-title {
-      font-size: 16px;
+      display: inline-block;
+      font-size: 1rem;
+      margin-left: 0.15rem;
       vertical-align: top;
+      max-width: 10rem;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
     }
   }
 

--- a/templates/details/_bundle_icon.html
+++ b/templates/details/_bundle_icon.html
@@ -1,7 +1,8 @@
 <a href="/{{charm.name}}" title="{{charm.title}}" alt="{{charm.name}}" class="p-bundle-icon" id="{{charm.name}}_id" style="background-image: url('https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,c_fill,w_24,h_24/https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg');"></a>
-<a href="/{{charm.name}}" class="p-bundle-icon-title" id="{{charm.name}}_link">
+<a href="/{{charm.name}}" title="{{charm.title}}" class="p-bundle-icon-title" id="{{charm.name}}_link">
   {{ charm.title }}
 </a>
+
 <script>
   fetch("/{{charm.name}}", { method: "HEAD" })
       .then((r) => {


### PR DESCRIPTION
## Done
- Truncate a charm icon title displayed within the column

## How to QA
- Go to https://charmhub-io-1765.demos.haus/kubernetes-core
- Go to https://charmhub-io-1765.demos.haus/canonical-livepatch-onprem
- Check if the charm icon title is within the column

## Issue / Card
Fixes #https://warthogs.atlassian.net/browse/WD-8967
