### PR TITLE
Add unit test for get_publisher_details

### DIFF
--- a/tests/store/test_get_publisher_details.py
+++ b/tests/store/test_get_publisher_details.py
@@ -1,0 +1,49 @@
+from unittest import TestCase
+from unittest.mock import patch
+from webapp.app import app
+import talisker
+from canonicalwebteam.store_api.stores.charmstore import CharmStore
+
+store_api = CharmStore(session=talisker.requests.get_session())
+
+
+class TestGetPublisherDetails(TestCase):
+    def setUp(self):
+        app.testing = True
+        self.client = app.test_client()
+
+    def test_get_publisher_details(self):
+        response = self.client.get("/publisher/test-publisher")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"publisher", response.data)
+        self.assertIn(b"test-publisher", response.data)
+        self.assertIn(b"charms", response.data)
+        self.assertIn(b"charms_count", response.data)
+        self.assertIn(b"error_info", response.data)
+
+    @patch("webapp.app.app.store_api.find")
+    def test_get_publisher_details_error_handling(self, mock_find):
+        mock_find.side_effect = Exception("Mocked Error")
+        with self.client as client:
+            with self.assertRaises(Exception) as context:
+                response = client.get("/publisher/test-publisher")
+                self.assertEqual(str(context.exception), "Mocked Error")
+                self.assertEqual(response.status_code, 500)
+
+    @patch("webapp.app.app.store_api.find")
+    def test_get_publisher_details_empty_response(self, mock_find):
+        mock_find.return_value = {"results": []}
+        with self.client as client:
+            response = client.get("/publisher/test-publisher")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(0, len(response.json["charms"]))
+            self.assertEqual(0, response.json["charms_count"])
+            self.assertEqual(0, len(response.json["error_info"]))
+            self.assertEqual(
+                "test-publisher", response.json["publisher"]["display-name"]
+            )
+            self.assertIn(b"publisher", response.data)
+            self.assertIn(b"test-publisher", response.data)
+            self.assertIn(b"charms", response.data)
+            self.assertIn(b"charms_count", response.data)
+            self.assertIn(b"error_info", response.data)


### PR DESCRIPTION
## Done
Adds unit test to make sure we are receiving publisher information when querying the /find endpoint.

## How to QA
`tests/store/test_get_publisher_details.py` should pass

## Issue / Card
https://warthogs.atlassian.net/browse/WD-9637
