### PR TITLE
Change configure terminology

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -12,6 +12,7 @@ openstack-charmers-keystone-saml-mellon: keystone-saml-mellon
 containers-etcd: etcd
 canonical-kubernetes: charmed-kubernetes
 search\??(?P<search>.*)?/?: /?{search}
+/(?P<charm>[A-Za-z0-9-]*[A-Za-z][A-Za-z0-9-]*)/configure: /{charm}/configuration
 
 jaas: https://jaas.ai/jaas
 docs/stable/about-juju: https://juju.is/about

--- a/templates/details/_details-tab-navigation.html
+++ b/templates/details/_details-tab-navigation.html
@@ -16,7 +16,7 @@
       </li>
       {% endif %}
       <li class="p-tabs__item" role="presentation">
-        <a href="/{{ package.name }}/configure{% if channel_requested %}?channel={{ channel_requested }}{% endif %}" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'configure' %}aria-selected="true" {% endif %}>Configure</a>
+        <a href="/{{ package.name }}/configuration{% if channel_requested %}?channel={{ channel_requested }}{% endif %}" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'configuration' %}aria-selected="true" {% endif %}>Configuration</a>
       </li>
       {% if package.type == "charm" %}
       <li class="p-tabs__item" role="presentation">

--- a/templates/details/configure-bundle.html
+++ b/templates/details/configure-bundle.html
@@ -1,4 +1,4 @@
-{% set current_tab = "configure" %}
+{% set current_tab = "configuration" %}
 
 {% extends '/details/details_layout.html' %}
 

--- a/templates/details/configure-charm.html
+++ b/templates/details/configure-charm.html
@@ -1,4 +1,4 @@
-{% set current_tab = "configure" %}
+{% set current_tab = "configuration" %}
 
 {% extends '/details/details_layout.html' %}
 

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -348,9 +348,13 @@ def details_docs(entity_name, path=None):
     return render_template("details/docs.html", **context)
 
 
-@store.route('/<regex("' + DETAILS_VIEW_REGEX + '"):entity_name>/configure')
 @store.route(
-    '/<regex("' + DETAILS_VIEW_REGEX + '"):entity_name>/configure/<path:path>'
+    '/<regex("' + DETAILS_VIEW_REGEX + '"):entity_name>/configuration'
+)
+@store.route(
+    '/<regex("'
+    + DETAILS_VIEW_REGEX
+    + '"):entity_name>/configuration/<path:path>'
 )
 @store_maintenance
 @redirect_uppercase_to_lowercase
@@ -370,7 +374,9 @@ def details_configuration(entity_name, path=None):
 
         if not path and bundle_charms:
             default_charm = bundle_charms[0]
-            redirect_url = f"/{entity_name}/configure/{default_charm['name']}"
+            redirect_url = (
+                f"/{entity_name}/configuration/{default_charm['name']}"
+            )
             if channel_request:
                 redirect_url = redirect_url + f"?channel={channel_request}"
             return redirect(redirect_url)


### PR DESCRIPTION
## Done
Modifies 'configure' to 'configuration' on Charm details pages. Also modifies URL to /<charm-name>/configuration

## How to QA
Charm details page should have a "configuration" tab instead of "configure". For example https://charmhub-io-1778.demos.haus/prometheus-k8s/configuration 

## Issue / Card
Fixes [WD-8675](https://warthogs.atlassian.net/browse/WD-8675) 


[WD-8675]: https://warthogs.atlassian.net/browse/WD-8675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ