### PR TITLE
add unit tests for get_interfaces and single_interface

### DIFF
--- a/tests/interfaces/test_interface_routes.py
+++ b/tests/interfaces/test_interface_routes.py
@@ -38,7 +38,7 @@ class TestInterfaceRoutes(TestCase):
         self.assertEqual(
             len(json_data["interfaces"]),
             1,
-            "Expected 1 interface in the response"
+            "Expected 1 interface in the response",
         )
         if json_data["interfaces"]:
             first_interface = json_data["interfaces"][0]

--- a/tests/interfaces/test_interface_routes.py
+++ b/tests/interfaces/test_interface_routes.py
@@ -1,12 +1,21 @@
+from contextlib import _RedirectStream
 from unittest import TestCase
 from unittest.mock import patch, MagicMock
 from webapp.app import app
+from flask import url_for
 
 
 class TestInterfaceRoutes(TestCase):
     def setUp(self):
-        app.testing = True
-        self.client = app.test_client()
+        self.app = app
+        self.app.config["TESTING"] = True
+        self.app.config["SERVER_NAME"] = "localhost.localdomain"
+        self.client = self.app.test_client()
+        self.context = self.app.app_context()
+        self.context.push()
+
+    def tearDown(self):
+        self.context.pop()
 
     @patch("webapp.interfaces.logic.Interfaces.get_interfaces")
     @patch("webapp.interfaces.logic.github_client.get_repo")
@@ -52,3 +61,34 @@ class TestInterfaceRoutes(TestCase):
                 "live",
                 "Interface status does not match expected value",
             )
+
+    @patch("webapp.interfaces.views.get_single_interface")
+    def test_single_interface_success(self, mock_get_single_interface):
+        mock_response = MagicMock()
+        mock_response.data.decode.return_value = (
+            '{"interface": {"name": "test_interface"}}'
+        )
+        mock_get_single_interface.return_value = mock_response
+
+        response = self.client.get(
+            url_for("interfaces.single_interface", path="test_interface")
+        )
+
+        self.assertEqual(response.status_code, 200)
+        mock_get_single_interface.assert_called_with("test_interface", "")
+
+    @patch('webapp.interfaces.views.get_single_interface')
+    def test_single_interface_draft_redirect(self, mock_get_single_interface):
+        mock_get_single_interface.side_effect = [Exception("Failed to retrieve"), _RedirectStream(url_for('interfaces.single_interface', path='test_interface/draft'))]
+
+        response = self.client.get(url_for('interfaces.single_interface', path='test_interface'))
+
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(response.location.endswith('test_interface/draft'))
+
+    @patch('webapp.interfaces.views.get_single_interface')
+    def test_single_interface_not_found(self, mock_get_single_interface):
+        mock_get_single_interface.side_effect = [Exception("Failed"), None]
+
+        response = self.client.get(url_for('interfaces.single_interface', path='nonexistent_interface'))
+        self.assertEqual(response.status_code, 404)

--- a/tests/interfaces/test_interface_routes.py
+++ b/tests/interfaces/test_interface_routes.py
@@ -1,0 +1,36 @@
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+from webapp.app import app
+import talisker
+from webapp.interfaces.logic import Interfaces
+
+class TestInterfaceRoutes(TestCase):
+    def setUp(self):
+        app.testing = True
+        self.client = app.test_client()
+
+    @patch('webapp.interfaces.logic.Interfaces.get_interfaces')
+    @patch('webapp.interfaces.logic.github_client.get_repo')
+    def test_get_interfaces(self, mock_get_repo, mock_get_interfaces):
+        mock_get_interfaces.return_value = [{'name': 'test_interface', 'readme_path': 'path/to/readme', 'status': 'live'}]
+
+        mock_repo = MagicMock()
+        mock_content = MagicMock()
+        mock_content.decoded_content.decode.return_value = 'Mock README content'
+        mock_repo.get_contents.return_value = mock_content
+        mock_get_repo.return_value = mock_repo
+
+        response = self.client.get('/interfaces.json')
+        self.assertEqual(response.status_code, 200)
+        json_data = response.json
+
+        self.assertIn('interfaces', json_data)
+        self.assertIsInstance(json_data['interfaces'], list)
+        for interface in json_data['interfaces']:
+            self.assertIn('description', interface)
+            self.assertIsInstance(interface['description'], str)
+        self.assertEqual(len(json_data['interfaces']), 1, "Expected 1 interface in the response")
+        if json_data['interfaces']:
+            first_interface = json_data['interfaces'][0]
+            self.assertEqual(first_interface['name'], 'test_interface', "Interface name does not match expected value")
+            self.assertEqual(first_interface['status'], 'live', "Interface status does not match expected value")

--- a/tests/interfaces/test_interface_routes.py
+++ b/tests/interfaces/test_interface_routes.py
@@ -82,7 +82,9 @@ class TestInterfaceRoutes(TestCase):
         mock_get_single_interface.side_effect = [
             Exception("Failed to retrieve"),
             _RedirectStream(
-                url_for("interfaces.single_interface", path="test_interface/draft")
+                url_for(
+                    "interfaces.single_interface", path="test_interface/draft"
+                )
             ),
         ]
 
@@ -98,6 +100,8 @@ class TestInterfaceRoutes(TestCase):
         mock_get_single_interface.side_effect = [Exception("Failed"), None]
 
         response = self.client.get(
-            url_for("interfaces.single_interface", path="nonexistent_interface")
+            url_for(
+                "interfaces.single_interface", path="nonexistent_interface"
+            )
         )
         self.assertEqual(response.status_code, 404)

--- a/tests/interfaces/test_interface_routes.py
+++ b/tests/interfaces/test_interface_routes.py
@@ -77,18 +77,27 @@ class TestInterfaceRoutes(TestCase):
         self.assertEqual(response.status_code, 200)
         mock_get_single_interface.assert_called_with("test_interface", "")
 
-    @patch('webapp.interfaces.views.get_single_interface')
+    @patch("webapp.interfaces.views.get_single_interface")
     def test_single_interface_draft_redirect(self, mock_get_single_interface):
-        mock_get_single_interface.side_effect = [Exception("Failed to retrieve"), _RedirectStream(url_for('interfaces.single_interface', path='test_interface/draft'))]
+        mock_get_single_interface.side_effect = [
+            Exception("Failed to retrieve"),
+            _RedirectStream(
+                url_for("interfaces.single_interface", path="test_interface/draft")
+            ),
+        ]
 
-        response = self.client.get(url_for('interfaces.single_interface', path='test_interface'))
+        response = self.client.get(
+            url_for("interfaces.single_interface", path="test_interface")
+        )
 
         self.assertEqual(response.status_code, 302)
-        self.assertTrue(response.location.endswith('test_interface/draft'))
+        self.assertTrue(response.location.endswith("test_interface/draft"))
 
-    @patch('webapp.interfaces.views.get_single_interface')
+    @patch("webapp.interfaces.views.get_single_interface")
     def test_single_interface_not_found(self, mock_get_single_interface):
         mock_get_single_interface.side_effect = [Exception("Failed"), None]
 
-        response = self.client.get(url_for('interfaces.single_interface', path='nonexistent_interface'))
+        response = self.client.get(
+            url_for("interfaces.single_interface", path="nonexistent_interface")
+        )
         self.assertEqual(response.status_code, 404)

--- a/tests/interfaces/test_interface_routes.py
+++ b/tests/interfaces/test_interface_routes.py
@@ -1,36 +1,51 @@
 from unittest import TestCase
 from unittest.mock import patch, MagicMock
 from webapp.app import app
-import talisker
-from webapp.interfaces.logic import Interfaces
+
 
 class TestInterfaceRoutes(TestCase):
     def setUp(self):
         app.testing = True
         self.client = app.test_client()
 
-    @patch('webapp.interfaces.logic.Interfaces.get_interfaces')
-    @patch('webapp.interfaces.logic.github_client.get_repo')
+    @patch("webapp.interfaces.logic.Interfaces.get_interfaces")
+    @patch("webapp.interfaces.logic.github_client.get_repo")
     def test_get_interfaces(self, mock_get_repo, mock_get_interfaces):
-        mock_get_interfaces.return_value = [{'name': 'test_interface', 'readme_path': 'path/to/readme', 'status': 'live'}]
+        mock_get_interfaces.return_value = [
+            {
+                "name": "test_interface",
+                "readme_path": "path/to/readme",
+                "status": "live",
+            }
+        ]
 
         mock_repo = MagicMock()
         mock_content = MagicMock()
-        mock_content.decoded_content.decode.return_value = 'Mock README content'
+        mock_content.decoded_content.decode.return_value = "Mock README content"
         mock_repo.get_contents.return_value = mock_content
         mock_get_repo.return_value = mock_repo
 
-        response = self.client.get('/interfaces.json')
+        response = self.client.get("/interfaces.json")
         self.assertEqual(response.status_code, 200)
         json_data = response.json
 
-        self.assertIn('interfaces', json_data)
-        self.assertIsInstance(json_data['interfaces'], list)
-        for interface in json_data['interfaces']:
-            self.assertIn('description', interface)
-            self.assertIsInstance(interface['description'], str)
-        self.assertEqual(len(json_data['interfaces']), 1, "Expected 1 interface in the response")
-        if json_data['interfaces']:
-            first_interface = json_data['interfaces'][0]
-            self.assertEqual(first_interface['name'], 'test_interface', "Interface name does not match expected value")
-            self.assertEqual(first_interface['status'], 'live', "Interface status does not match expected value")
+        self.assertIn("interfaces", json_data)
+        self.assertIsInstance(json_data["interfaces"], list)
+        for interface in json_data["interfaces"]:
+            self.assertIn("description", interface)
+            self.assertIsInstance(interface["description"], str)
+        self.assertEqual(
+            len(json_data["interfaces"]), 1, "Expected 1 interface in the response"
+        )
+        if json_data["interfaces"]:
+            first_interface = json_data["interfaces"][0]
+            self.assertEqual(
+                first_interface["name"],
+                "test_interface",
+                "Interface name does not match expected value",
+            )
+            self.assertEqual(
+                first_interface["status"],
+                "live",
+                "Interface status does not match expected value",
+            )

--- a/tests/interfaces/test_interface_routes.py
+++ b/tests/interfaces/test_interface_routes.py
@@ -21,7 +21,8 @@ class TestInterfaceRoutes(TestCase):
 
         mock_repo = MagicMock()
         mock_content = MagicMock()
-        mock_content.decoded_content.decode.return_value = "Mock README content"
+        readme_content = "Mock README content"
+        mock_content.decoded_content.decode.return_value = readme_content
         mock_repo.get_contents.return_value = mock_content
         mock_get_repo.return_value = mock_repo
 
@@ -35,7 +36,9 @@ class TestInterfaceRoutes(TestCase):
             self.assertIn("description", interface)
             self.assertIsInstance(interface["description"], str)
         self.assertEqual(
-            len(json_data["interfaces"]), 1, "Expected 1 interface in the response"
+            len(json_data["interfaces"]),
+            1,
+            "Expected 1 interface in the response"
         )
         if json_data["interfaces"]:
             first_interface = json_data["interfaces"][0]


### PR DESCRIPTION
## Done
- add a unit test for `get_interfaces` to fetch a list of interfaces and descriptions 
- add a unit test for `single_interface` in different scenarios: 1) successful retrieval, 2) exception handling retrieving a draft interface, and 3) failure to find both the primary and draft interfaces, leading to a 404 response

## How to QA
- `tests/interfaces/test_interface_routes.py` should pass

## Issue / Card
Fixes #https://warthogs.atlassian.net/browse/WD-9791
