### PR TITLE
Add a link to juju docs pages on the integration tab 

### DIFF
--- a/static/js/src/public/details/integrations/components/App/App.tsx
+++ b/static/js/src/public/details/integrations/components/App/App.tsx
@@ -150,10 +150,15 @@ export const App = () => {
           <Col size={9} className="p-details-tab__content__body">
             <Row>
               <Col size={5}>
-                <h2 className="p-heading--3">
+                <h2 className="p-heading--3 p-details-tab__content__body__title">
                   {integrationCount} integration
-                  {integrationCount > 1 ? "s" : ""} related to this charm
+                  {integrationCount > 1 ? "s" : ""}
                 </h2>
+                <h3 className="p-heading--4 p-details-tab__content__body__link">
+                  <a href="https://juju.is/docs/juju/relation">
+                    Learn about integrations &gt;
+                  </a>
+                </h3>
               </Col>
               <Col size={4}>
                 <div

--- a/static/js/src/public/details/integrations/components/App/App.tsx
+++ b/static/js/src/public/details/integrations/components/App/App.tsx
@@ -154,11 +154,11 @@ export const App = () => {
                   {integrationCount} integration
                   {integrationCount > 1 ? "s" : ""}
                 </h2>
-                <h3 className="p-heading--4 p-details-tab__content__body__link">
+                <p className="p-heading--4 p-details-tab__content__body__link">
                   <a href="https://juju.is/docs/juju/relation">
-                    Learn about integrations &gt;
+                    Learn about integrations&nbsp;&gt;
                   </a>
-                </h3>
+                </p>
               </Col>
               <Col size={4}>
                 <div

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -301,6 +301,12 @@ body {
       }
     }
   }
+
+  .p-details-tab__content__body .p-details-tab__content__body__title,
+  .p-details-tab__content__body .p-details-tab__content__body__link {
+    display: inline;
+    margin-right: 1rem;
+  }
 }
 
 // Override h3 font weight based on design feedback from MS


### PR DESCRIPTION
## Done
- Add a link to juju docs pages next to a heading on the integration tab 

## How to QA
- Go to https://charmhub-io-1787.demos.haus/mongodb/integrations
- Check if you see `Learn about integrations >` link which directs to `https://juju.is/docs/juju/relation`

## Issue / Card
Fixes #https://warthogs.atlassian.net/browse/WD-9926

## Screenshots
<img width="1270" alt="Screenshot 2024-04-09 at 2 06 12 PM" src="https://github.com/canonical/charmhub.io/assets/90341644/9e7dea3a-caf6-4f46-a4f8-28845d90f073">
