### PR TITLE
WD-10256 Make the add topology icon directly trigger the file input and add a notification in the bundle listing form

### DIFF
--- a/static/sass/_charmhub_publisher.scss
+++ b/static/sass/_charmhub_publisher.scss
@@ -213,6 +213,16 @@
       }
     }
 
+    #bundle-topology {
+      height: 100%;
+      left: 0;
+      opacity: 0;
+      position: absolute;
+      top: 0;
+      width: 100%;
+      z-index: 1;
+    }
+
     .p-icon--delete {
       @include vf-icon-delete($color-mid-dark);
 

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -9,7 +9,7 @@
 {% block publisher_content %}
 <form id="market-form" class="p-form p-form--stacked p-strip u-no-padding--top" method="POST" enctype="multipart/form-data">
   <div class="row" style="padding-top: 1rem">
-    <div class="p-notification--information">
+    <div class="p-notification--caution">
       <div class="p-notification__content">
         <p class="p-notification__message">A published {{ package.type }} is required to successfully save this form.</p>
     </div>

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -121,7 +121,8 @@
               <div class=" p-file-input">
                 <div class="p-market-banner__image is-empty" tabindex="0">
                   <div class="u-align-text--center"><i class="p-icon--plus"></i>Add topology</div>
-                </div><input type="file" name="bundle-topology" id="bundle-topology" accept="image/png,image/jpeg" hidden="">
+                </div><input type="file" name="bundle-topology" id="bundle-topology" accept="image/png,image/jpeg">
+                <div id="file-name-display" style="margin-bottom: 1rem;"></div>
               </div>
             </div>
             <p class="p-form-help-text">Reposition charm icons in a manner that is both meaningful and memorable. To manipulate charms in the canvas, click and drag.</p>
@@ -179,5 +180,12 @@
     };
     charmhub.publisher.listing.init(formFields);
   });
+
+  document.getElementById('bundle-topology').addEventListener('change', function () {
+      var fileNameDisplay = document.getElementById('file-name-display');
+      if (this.files && this.files.length > 0) {
+        fileNameDisplay.textContent = this.files[0].name;
+      }
+    });
 </script>
 {% endblock%}

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -9,6 +9,13 @@
 {% block publisher_content %}
 <form id="market-form" class="p-form p-form--stacked p-strip u-no-padding--top" method="POST" enctype="multipart/form-data">
   <div class="row" style="padding-top: 1rem">
+    <div class="p-notification--information">
+      <div class="p-notification__content">
+        <p class="p-notification__message">A published {{ package.type }} is required to successfully save this form.</p>
+    </div>
+  </div>
+  </form>
+  <div class="row">
     <div class="col-7">
       <p style="margin-bottom: 1rem;">
         Updates to this information will appear immediately on the <a href="/{{ package.name }}">{{ package.type }} listing page</a>.


### PR DESCRIPTION
## Done
- On a bundle listing page, instead of using the `hidden` attribute, add styling to make the `Add topology` icon directly trigger the file input
- Add a notification to display a message about a successful form submission

## How to QA
- Go to https://charmhub-io-1788.demos.haus/:your-bundle/listing
- Check if you see a notification on the top of the bundle listing form
- Check if you can click `Add topology` field and upload an image
- Check if the name of the uploaded image is shown below the `Add topology` field

## Issue / Card
Fixes #https://warthogs.atlassian.net/browse/WD-10256

