### PR TITLE
Add email link for collaborator invite

### DIFF
--- a/static/js/src/publisher/collaboration/atoms.ts
+++ b/static/js/src/publisher/collaboration/atoms.ts
@@ -31,3 +31,8 @@ export const inviteLinkState = atom({
   key: "inviteLink",
   default: "" as string | undefined,
 });
+
+export const inviteEmailLinkState = atom({
+  key: "inviteEmailLink",
+  default: "" as string | undefined,
+});

--- a/static/js/src/publisher/collaboration/components/Collaboration.tsx
+++ b/static/js/src/publisher/collaboration/components/Collaboration.tsx
@@ -25,6 +25,7 @@ import {
   invitesListState,
   activeInviteEmailState,
   inviteLinkState,
+  inviteEmailLinkState,
   filterQueryState,
 } from "../atoms";
 import {
@@ -55,6 +56,7 @@ function Collaboration() {
   const invitesList = useRecoilValue(filteredInvitesListState);
   const activeInviteEmail = useRecoilValue(activeInviteEmailState);
   const inviteLink = useRecoilValue(inviteLinkState);
+  const inviteEmailLink = useRecoilValue(inviteEmailLinkState);
   const filterQuery = useRecoilValue(filterQueryState);
   const { data: collaboratorsData } = useCollaboratorsQuery(packageName);
   const { data: invitesData } = useInvitesQuery(packageName);
@@ -118,12 +120,31 @@ function Collaboration() {
               {showInviteSuccess && (
                 <Notification
                   severity="positive"
+                  title="An invite has been created"
                   onDismiss={() => {
                     setShowInviteSuccess(false);
                   }}
                 >
-                  An invite has been created.{" "}
-                  <a href={inviteLink}>Accept invite</a>.
+                  <p>
+                    <a target="_blank" href={inviteEmailLink}>
+                      Send the invite by email
+                    </a>{" "}
+                    or copy link:
+                  </p>
+                  <div>
+                    <input
+                      className="u-no-margin--bottom"
+                      type="text"
+                      readOnly
+                      value={inviteLink}
+                      style={{
+                        color: "inherit",
+                      }}
+                      onFocus={(e) => {
+                        e.target.select();
+                      }}
+                    />
+                  </div>
                 </Notification>
               )}
 

--- a/static/js/src/publisher/collaboration/components/InviteCollaborator.tsx
+++ b/static/js/src/publisher/collaboration/components/InviteCollaborator.tsx
@@ -15,6 +15,8 @@ import {
   activeInviteEmailState,
   invitesListState,
   inviteLinkState,
+  inviteEmailLinkState,
+  publisherState,
 } from "../atoms";
 import { useSendMutation } from "../hooks";
 
@@ -37,12 +39,16 @@ function InviteCollaborator({
     activeInviteEmailState
   );
   const setInviteLink = useSetRecoilState(inviteLinkState);
+  const setInviteEmailLink = useSetRecoilState(inviteEmailLinkState);
   const invitesList = useRecoilValue(invitesListState);
+  const publisher = useRecoilValue(publisherState);
 
   const sendMutation = useSendMutation(
     packageName,
+    publisher?.["display-name"],
     activeInviteEmail,
     setInviteLink,
+    setInviteEmailLink,
     setShowInviteSuccess,
     setShowInviteError,
     queryClient,

--- a/static/js/src/publisher/collaboration/components/InviteConfirmationModal.tsx
+++ b/static/js/src/publisher/collaboration/components/InviteConfirmationModal.tsx
@@ -9,6 +9,8 @@ import {
   invitesListState,
   inviteLinkState,
   collaboratorsListState,
+  inviteEmailLinkState,
+  publisherState,
 } from "../atoms";
 import {
   filteredInvitesListState,
@@ -37,15 +39,19 @@ function InviteConfirmationModal({
   const invitesList = useRecoilValue(filteredInvitesListState);
   const setCollaboratorsList = useSetRecoilState(collaboratorsListState);
   const collaboratorsList = useRecoilValue(filteredCollaboratorsListState);
+  const publisher = useRecoilValue(publisherState);
   const setInviteLink = useSetRecoilState(inviteLinkState);
+  const setInviteEmailLink = useSetRecoilState(inviteEmailLinkState);
   const [activeInviteEmail, setActiveInviteEmail] = useRecoilState(
     activeInviteEmailState
   );
 
   const sendMutation = useSendMutation(
     packageName,
+    publisher?.["display-name"],
     activeInviteEmail,
     setInviteLink,
+    setInviteEmailLink,
     setShowSuccess,
     setShowError,
     queryClient,

--- a/static/js/src/publisher/collaboration/hooks.ts
+++ b/static/js/src/publisher/collaboration/hooks.ts
@@ -42,8 +42,10 @@ export function useInvitesQuery(packageName: string | undefined) {
 
 export function useSendMutation(
   packageName: string | undefined,
+  publisherName: string | undefined,
   activeInviteEmail: string | undefined,
   setInviteLink: Function,
+  setInviteEmailLink: Function,
   setShowInviteSuccess: Function,
   setShowInviteError: Function,
   queryClient: any,
@@ -83,8 +85,10 @@ export function useSendMutation(
       }
 
       // This shouldn't be necessary once emails are enabled
-      setInviteLink(
-        `/accept-invite?package=${packageName}&token=${inviteData.data[0].token}`
+      const inviteLink = `https://charmhub.io/accept-invite?package=${packageName}%26token=${inviteData.data[0].token}`;
+      setInviteLink(inviteLink);
+      setInviteEmailLink(
+        `mailto:${inviteData.data[0].email}?subject=${publisherName} has invited you to collaborate on ${packageName}&body=Click this link to accept the invite: ${inviteLink}`
       );
 
       setShowInviteSuccess(true);


### PR DESCRIPTION
## Done
Added a link to send the invite to an invited collaborator

## How to QA
- Go to https://charmhub-io-1791.demos.haus/<CHARM_NAME>/collaboration
- Click on "Add new collaborator"
- Type in an email address and submit the form
- Check that the success notification has a link that opens a new email populated with the invitees email address and invite link
- Check that there is an input with the full link

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-10396

## Screenshot
![screenshot](https://github.com/canonical/charmhub.io/assets/501889/297b74b4-f2de-4a5a-8dc0-f571144746ff)
