### PR TITLE
Add collaboration to charm navigation

### DIFF
--- a/templates/publisher/publisher_layout.html
+++ b/templates/publisher/publisher_layout.html
@@ -25,6 +25,11 @@
           </a>
         </li>
         <li class="p-tabs__item" role="presentation">
+          <a href="/{{package.name}}/collaboration" class="p-tabs__link" tabindex="0" role="tab" {% if selected_tab == "collaboration" %}aria-selected="true"{% endif %}>
+            Collaboration
+          </a>
+        </li>
+        <li class="p-tabs__item" role="presentation">
           <a href="/{{package.name}}/settings" class="p-tabs__link" tabindex="0" role="tab" {% if selected_tab == "settings" %}aria-selected="true"{% endif %}>
             Settings
           </a>


### PR DESCRIPTION
## Done
Added "Collaboration" to the charm section navigation

## How to QA
- Go to https://charmhub-io-1792.demos.haus/<CHARM_NAME>/collaboration
- Check that "Collaboration" is in the section navigation

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-10397