### PR TITLE
add links to juju docs in header, action page and configure page

### DIFF
--- a/static/sass/_charmhub_p-header.scss
+++ b/static/sass/_charmhub_p-header.scss
@@ -30,6 +30,11 @@
       }
     }
 
+    &__action {
+      margin-block-start: $spv--small;
+      padding-inline-start: $spv--small;
+    }
+
     .p-button--base {
       margin-block-end: 0;
       width: fit-content;

--- a/templates/details/actions.html
+++ b/templates/details/actions.html
@@ -20,6 +20,11 @@
         </div>
       </div>
       <div class="col-9">
+        <p class="p-heading--4">
+          <a href="https://juju.is/docs/juju/action" class="" target="_blank" rel="noopener noreferrer">
+            Learn about actions&nbsp;&gt;
+          </a>
+        </p>
         <ul class="p-list--divided has-separator-centered">
           {% for action, action_data in package.store_front.actions.items() %}
             <li class="p-list__item" style="margin-bottom: 1rem;" id="{{ action }}">

--- a/templates/details/configure-bundle.html
+++ b/templates/details/configure-bundle.html
@@ -23,7 +23,7 @@
   <div class="col-9">
     {% if subpackage and subpackage.store_front.config.options %}
     <p class="p-heading--4">
-      <a href="https://juju.is/docs/juju/action" class="" target="_blank" rel="noopener noreferrer">
+      <a href="https://juju.is/docs/juju/configuration#heading--application-configuration" class="" target="_blank" rel="noopener noreferrer">
         Learn about configurations&nbsp;&gt;
       </a>
     </p>

--- a/templates/details/configure-bundle.html
+++ b/templates/details/configure-bundle.html
@@ -22,6 +22,11 @@
 
   <div class="col-9">
     {% if subpackage and subpackage.store_front.config.options %}
+    <p class="p-heading--4">
+      <a href="https://juju.is/docs/juju/action" class="" target="_blank" rel="noopener noreferrer">
+        Learn about configurations&nbsp;&gt;
+      </a>
+    </p>
       <ul class="p-list--divided has-separator-centered">
         {% for key, value in subpackage.store_front.config.options.items() %}
         <li class="p-list__item" id="{{ key }}">

--- a/templates/details/configure-charm.html
+++ b/templates/details/configure-charm.html
@@ -19,6 +19,11 @@
     </div>
   </div>
   <div class="col-9">
+    <p class="p-heading--4">
+      <a href="https://juju.is/docs/juju/configuration#heading--application-configuration" class="" target="_blank" rel="noopener noreferrer">
+        Learn about configurations&nbsp;&gt;
+      </a>
+    </p>
     <ul class="p-list--divided has-separator-centered">
       {% for key, value in package.store_front.config.options.items() %}
       <li class="p-list__item" id="{{ key }}">

--- a/templates/partial/_channel-map.html
+++ b/templates/partial/_channel-map.html
@@ -89,4 +89,12 @@
       </div>
     </div>
   </div>
+
+  <div class="p-charm-header__action">
+    <p class="p-heading--4">
+      <a href="https://juju.is/docs/juju/manage-applications" class="" target="_blank" rel="noopener noreferrer">
+        Learn to deploy on juju&nbsp;&gt;
+      </a>
+    </p>
+
 </div>


### PR DESCRIPTION
## Done
- add links to juju docs in header, action page and configure page
## How to QA
- Go to [https://charmhub-io-1794.demos.haus/< charm-name >](https://charmhub-io-1794.demos.haus/<charm-name>) and ensure there is a link (with text `Learn to deploy on juju`) to juju docs that should open https://juju.is/docs/juju/manage-applications on a blank page
- Go to [https://charmhub-io-1794.demos.haus/< charm-name >/configuration](https://charmhub-io-1794.demos.haus/<charm-name>/configuration) ensure there is a link to juju docs configuration that opens on a blank page
- Go to [https://charmhub-io-1794.demos.haus/< charm-name >/actions](https://charmhub-io-1794.demos.haus/<charm-name>/actions) and ensure there is a link to juju docs actions that also opens on a blank page
## Issue / Card https://warthogs.atlassian.net/browse/WD-10455
Fixes #

## Screenshots
