### PR TITLE
Fix link alignment on Charm header

### DIFF
--- a/templates/partial/_channel-map.html
+++ b/templates/partial/_channel-map.html
@@ -91,7 +91,7 @@
   </div>
 
   <div class="p-charm-header__action" style="padding-left: 1rem;">
-    <p style="padding-top: 1rem">
+    <p style="padding-top: 0.5rem">
       <a href="https://juju.is/docs/juju/manage-applications" class="" target="_blank" rel="noopener noreferrer">
         Learn to deploy on juju&nbsp;&gt;
       </a>


### PR DESCRIPTION
## Done
- Fixed link alignment on Charm header

## How to QA
- Go to https://charmhub-io-1798.demos.haus/postgresql-k8s and check the link is aligned with other elements

## Issue / Card
Fixes #https://github.com/canonical/charmhub.io/issues/1795

## Screenshots
<img width="1344" alt="Screenshot 2024-04-23 at 9 32 34 AM" src="https://github.com/canonical/charmhub.io/assets/90341644/0f8dd822-c6ea-43b3-a690-70e751d75782">
