### PR TITLE
Fix collaborator invite link encoding

### DIFF
--- a/static/js/src/publisher/collaboration/hooks.ts
+++ b/static/js/src/publisher/collaboration/hooks.ts
@@ -85,10 +85,10 @@ export function useSendMutation(
       }
 
       // This shouldn't be necessary once emails are enabled
-      const inviteLink = `https://charmhub.io/accept-invite?package=${packageName}%26token=${inviteData.data[0].token}`;
+      const inviteLink = `https://charmhub.io/accept-invite?package=${packageName}&token=${inviteData.data[0].token}`;
       setInviteLink(inviteLink);
       setInviteEmailLink(
-        `mailto:${inviteData.data[0].email}?subject=${publisherName} has invited you to collaborate on ${packageName}&body=Click this link to accept the invite: ${inviteLink}`
+        `mailto:${inviteData.data[0].email}?subject=${publisherName} has invited you to collaborate on ${packageName}&body=Click this link to accept the invite: ${encodeURIComponent(inviteLink)}`
       );
 
       setShowInviteSuccess(true);


### PR DESCRIPTION
## Done
Fixed the encoding of the collaborator invite link

## How to QA
- Go to https://charmhub-io-1804.demos.haus/<CHARM_NAME>/collaboration
- Invite a collaborator
- The link in the success notification should not be encoded (i.e. the `&` between the package name and `token` should be an `8`
