### PR TITLE
Modify provides or requires

### DIFF
--- a/static/js/src/public/details/integrations/components/InterfaceItem.tsx
+++ b/static/js/src/public/details/integrations/components/InterfaceItem.tsx
@@ -149,7 +149,7 @@ export const InterfaceItem = ({
           <div style={{ paddingTop: "0.5rem" }}>
             <p className="u-fixed-width u-no-margin--bottom">
               The <b>{interfaceData.key}</b> endpoint
-              <b>{interfaceType === "requires" ? " provides " : " requires "}</b> 
+              <b>{interfaceType === "requires" ? " requires " : " provides "}</b> 
               an integration over the {" "}
               <a href={`/interfaces/${interfaceData.interface}`}>
                 {interfaceData.interface}
@@ -182,7 +182,7 @@ export const InterfaceItem = ({
         <div className="u-fixed-width">
           <p>
             No charms found that{" "}
-            <b>{interfaceType === "requires" ? "provide" : "consume"}</b>{" "}
+            <b>{interfaceType === "requires" ? "require" : "provide"}</b>{" "}
             {interfaceData.interface}
           </p>
         </div>


### PR DESCRIPTION
## Done
Fixes an issue from my previous [PR](https://github.com/canonical/charmhub.io/pull/1803). Modifies whether an endpoint requires or provides an interface, also fixes terminology when there are no charms found that require / provide an interface

## How to QA
Go to https://charmhub-io-1805.demos.haus/grafana-k8s/integrations and make sure the `requires` or `provides` terminology matches the [mockup](https://app.zeplin.io/project/65d5c15738e94cbad01d2799/screen/65f02495d37744a4ebaa9af2).

