### PR TITLE
Make sure Sentry DSN is accessible from the front-end

### DIFF
--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -1,4 +1,5 @@
 from flask import render_template, session
+from webapp.config import SENTRY_DSN
 
 from canonicalwebteam.store_api.exceptions import (
     StoreApiError,
@@ -31,6 +32,7 @@ def charmhub_utility_processor():
         "schedule_banner": helpers.schedule_banner,
         "account": account,
         "image": image_template,
+        "SENTRY_DSN": SENTRY_DSN,
     }
 
 


### PR DESCRIPTION
## Done
Made Sentry DSN available on the front-end

## How to QA
- Go to https://charmhub-io-1816.demos.haus/<CHARM_NAME>/listing
- Type `window.SENTRY_DSN` and check that it has a value