### PR TITLE
fix: remove redirect canonical-kubernetes redirect

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -10,7 +10,6 @@ overview: https://juju.is/about
 kubeflow-charmers-kubeflow-edge: kubeflow-edge
 openstack-charmers-keystone-saml-mellon: keystone-saml-mellon
 containers-etcd: etcd
-canonical-kubernetes: charmed-kubernetes
 search\??(?P<search>.*)?/?: /?{search}
 /(?P<charm>[A-Za-z0-9-]*[A-Za-z][A-Za-z0-9-]*)/configure: /{charm}/configuration
 


### PR DESCRIPTION
It's no longer desirable to redirect canonical-kubernetes to charmed-kubernetes. See: https://chat.canonical.com/canonical/pl/b4xh1nrauf873fwj1s5tr1xx6e

## Done
Removed redirect

## How to QA
- Visit https://charmhub-io-1818.demos.haus/canonical-kubernetes - see Canonical Kubernetes
- Visit https://charmhub-io-1818.demos.haus/charmed-kubernetes - see Charmed Kubernetes
- Celebrate
