### PR TITLE
Add Juju middle pages on Charmhub

### DIFF
--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -18,6 +18,9 @@
     </div>
     <nav class="p-navigation__nav">
       <ul class="p-navigation__items">
+        <li class="p-navigation__item">
+          <a class="p-navigation__link" href="http://juju.is/why-juju">How Juju Works</a>
+        </li>
         <li class="p-navigation__item{% if request.path == '/' %} is-selected{% endif %}">
           <a class="p-navigation__link" href="/">Charmhub</a>
         </li>


### PR DESCRIPTION
## Done
- Add Juju middle pages on Charmhub

## How to QA
- Go to https://charmhub-io-1820.demos.haus/ 
- Check the main navigation looks the same as [Juju.is](https://juju.is) and if you can access `How Juju Works` from the main navigation 

## Issue / Card
Fixes #https://warthogs.atlassian.net/browse/WD-11204

## Screenshots
<img width="1421" alt="Screenshot 2024-05-10 at 2 02 14 PM" src="https://github.com/canonical/charmhub.io/assets/90341644/6c06a10d-0cc9-490f-a6bd-544e7064521d">

