### PR TITLE
refactor interface page and cache for a day

### DIFF
--- a/webapp/integrations/logic.py
+++ b/webapp/integrations/logic.py
@@ -71,22 +71,6 @@ class Interfaces:
             self.last_fetch = time.time()
         return self.interfaces
 
-    def get_interface_cont_from_repo(
-        self, interface, status, content_type, version=None
-    ):
-        if version is None:
-            version = self.get_interface_latest_version(interface, status)
-
-        interface_path = "interfaces/{}/v{}".format(interface, version)
-        interface_content = self.repo.get_contents(interface_path)
-
-        content = [
-            path
-            for path in interface_content
-            if path.path.endswith(content_type)
-        ]
-        return content
-
     def repo_has_interface(self, interface):
         try:
             self.repo.get_contents("interfaces/{}".format(interface))

--- a/webapp/integrations/views.py
+++ b/webapp/integrations/views.py
@@ -106,14 +106,14 @@ def get_single_interface(interface_name, status):
 
     interface = interface_logic.get_interface_from_path(interface_name)
 
-    readme_contentfile = interface_logic.get_interface_cont_from_repo(
-        interface_name, status, "README.md", interface["version"]
+    readme_contentfile = interface_logic.repo.get_contents(
+        f"interfaces/{interface_name}/v{interface["version"]}/README.md"
     )
-    last_modified = datetime.strptime(
-        readme_contentfile[0].last_modified, "%a, %d %b %Y %H:%M:%S %Z"
-    ).isoformat()
+    readme = readme_contentfile.decoded_content.decode("utf-8")
 
-    readme = readme_contentfile[0].decoded_content.decode("utf-8")
+    last_modified = datetime.strptime(
+        readme_contentfile.last_modified, "%a, %d %b %Y %H:%M:%S %Z"
+    ).isoformat()
 
     res["body"] = interface_logic.convert_readme(
         interface_name, f"v{interface['version']}", readme, 2
@@ -135,5 +135,5 @@ def get_single_interface(interface_name, status):
     }
 
     response = make_response(res)
-    response.cache_control.max_age = "3600"
+    response.cache_control.max_age = "76800"
     return response

--- a/webapp/integrations/views.py
+++ b/webapp/integrations/views.py
@@ -107,7 +107,7 @@ def get_single_interface(interface_name, status):
     interface = interface_logic.get_interface_from_path(interface_name)
 
     readme_contentfile = interface_logic.repo.get_contents(
-        f"interfaces/{interface_name}/v{interface["version"]}/README.md"
+        f"interfaces/{interface_name}/v{interface['version']}/README.md"
     )
     readme = readme_contentfile.decoded_content.decode("utf-8")
 


### PR DESCRIPTION
## Done
- Refactor fetching of interface readme from the repo
- Cache page for a day
## How to QA
- Go to https://charmhub-io-1823.demos.haus/integrations/{interface-name}.json and ensure that a json response is returned as expected e.g https://charmhub-io-1823.demos.haus/integrations/ingress.json
- Got to https://charmhub-io-1823.demos.haus/integrations/{interface-name} and ensure that the page shows as expected e.g https://charmhub-io-1823.demos.haus/integrations/ingress
## Testing
[ ] No testing required (explain why):
This PR is a refactor of the logic and the existing tests still covers it.

## Issue / Card https://warthogs.atlassian.net/browse/WD-10963
Fixes #

## Screenshots
