### PR TITLE
fix: handle discourse topic not found

### DIFF
--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -20,6 +20,32 @@ PLATFORMS = {
 }
 
 
+def add_description_and_summary(package):
+    if package["type"] == "bundle":
+        description = (
+            package.get("store_front", {})
+            .get("bundle", {})
+            .get("description", None)
+        )
+        summary = (
+            package.get("store_front", {})
+            .get("bundle", {})
+            .get("summary", None)
+        )
+    else:
+        description = (
+            package.get("store_front", {})
+            .get("metadata", {})
+            .get("description", None)
+        )
+        summary = (
+            package.get("store_front", {})
+            .get("metadata", {})
+            .get("summary", None)
+        )
+    return description, summary
+
+
 def get_banner_url(media):
     """
     Get banner url from media object


### PR DESCRIPTION
## Done
- handle exception when discourse topic returns 404
## How to QA
- Go https://charmhub-io-1829.demos.haus/snap-store-proxy-charm and check if the page displays, check that other charms and topic also displays as expected
## Testing
- [ ] This PR has tests
- [x] No testing required (explain why):
This is a bug fix 

## Issue / Card
Fixes #

## Screenshots
