### PR TITLE
ci: add requirements and pylint to tics report step

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,7 +3,6 @@ on:
   schedule:
     - cron: "0 22 * * *"
 
-
 jobs:
   test:
     name: test
@@ -112,15 +111,12 @@ jobs:
           name: charmhubio-coverage
           path: coverage
 
-      - name: Install Dotrun
+      - name: Install Python requirements
         run: |
-          sudo pip3 install dotrun requests==2.31.0 # requests version is pinned to avoid breaking changes, can be removed once issue is resolved: https://github.com/docker/docker-py/issues/3256
+          sudo pip3 install -r requirements.txt
 
-      - name: Install dependencies
-        run: |
-          set -x
-          sudo chmod 0777 .
-          dotrun install
+      - name: Install Python dependencies
+        run: sudo pip3 install pylint
 
       - name: Produce TICS report
         shell: bash


### PR DESCRIPTION
## Done
Updated tics report step to ensure flake8 and pylint are present for TICS reporter.

## How to QA
- This job should have succeeded: https://github.com/canonical/charmhub.io/actions/runs/9413329910
- The TICS dashboard should have had a *tiny* bump today

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): CI Update

## Issue / Card
Fixes an issue in an email received from the TICS team

## Screenshots
