### PR TITLE
fix: integrations tab shows correct charms for each channel

### DIFF
--- a/static/js/src/public/details/integrations/components/App/App.tsx
+++ b/static/js/src/public/details/integrations/components/App/App.tsx
@@ -12,7 +12,14 @@ import { useRecoilState, useRecoilValue } from "recoil";
 import { filterChipsSelector, filterState } from "../../state";
 
 const getIntegrations = async (charm: string): Promise<IInterfaceData[]> => {
-  const resp = await fetch(`/${charm}/integrations.json`);
+  let resp;
+  const url = new URL(document.location.href);
+  const selectedChannel = url.searchParams.get("channel");
+  if (selectedChannel) {
+    resp = await fetch(`/${charm}/integrations.json?channel=${selectedChannel}`);
+  } else {
+    resp = await fetch(`/${charm}/integrations.json`);
+  }
   const json = await resp.json();
   if (!json.grouped_relations) {
     return [];

--- a/static/js/src/public/details/integrations/components/InterfaceItem.tsx
+++ b/static/js/src/public/details/integrations/components/InterfaceItem.tsx
@@ -162,13 +162,15 @@ export const InterfaceItem = ({
           </div>
           <Row>
             {charms.map((charm: ICharm) => (
-              <Col
-              size={3}
-              style={{ marginBottom: "1.5rem" }}
-              key={charm.package["display_name"]}
-              >
-                <IntegrationCard data={charm} />
-              </Col>
+              <>
+                <Col
+                size={3}
+                style={{ marginBottom: "1.5rem" }}
+                key={charm.package["display_name"]}
+                >
+                  <IntegrationCard data={charm} />
+                </Col>
+              </>
             ))}
           </Row>
         </>


### PR DESCRIPTION
## Done
- Changes path to query for integrations to take the selected channel into account.
- Also removes duplicated charm cards in integrations.

## How to QA
- Check https://charmhub-io-1848.demos.haus/mongodb/integrations and change channel
- Integrations supported should change depending on the channel
- Check duplicated cards against the current version (https://charmhub.io/mongodb/integrations)

## Testing
- [ ] This PR has tests
- [X] No testing required (explain why): bug fix

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-11698

