### PR TITLE
fix: add a chip to integration tabs when required property is set to true in metadata.yaml

### DIFF
--- a/static/js/src/public/details/integrations/components/App/App.tsx
+++ b/static/js/src/public/details/integrations/components/App/App.tsx
@@ -134,7 +134,7 @@ export const App = () => {
                   }}
                 >
                   {`${interfaceItem.key}`}
-                  {interfaceItem.optional && (
+                  {interfaceItem.optional === "true" && (
                   <Chip
                     value="Required"
                     appearance="negative"

--- a/static/js/src/public/details/integrations/components/App/App.tsx
+++ b/static/js/src/public/details/integrations/components/App/App.tsx
@@ -134,7 +134,7 @@ export const App = () => {
                   }}
                 >
                   {`${interfaceItem.key}`}
-                  {interfaceItem.optional === "true" && (
+                  {interfaceItem.optional && (
                   <Chip
                     value="Required"
                     appearance="negative"

--- a/static/js/src/public/details/integrations/components/App/App.tsx
+++ b/static/js/src/public/details/integrations/components/App/App.tsx
@@ -134,7 +134,7 @@ export const App = () => {
                   }}
                 >
                   {`${interfaceItem.key}`}
-                  {interfaceItem.optional === "true" && (
+                  {interfaceItem.required === true && (
                   <Chip
                     value="Required"
                     appearance="negative"

--- a/static/js/src/public/details/integrations/components/App/App.tsx
+++ b/static/js/src/public/details/integrations/components/App/App.tsx
@@ -6,6 +6,7 @@ import {
   Col,
   Spinner,
   SearchAndFilter,
+  Chip
 } from "@canonical/react-components";
 import { InterfaceItem } from "../InterfaceItem";
 import { useRecoilState, useRecoilValue } from "recoil";
@@ -122,7 +123,7 @@ export const App = () => {
                     e.preventDefault();
                     const target = e.target as HTMLLinkElement;
                     const targetElId = target.getAttribute("href");
-  
+
                     if (targetElId) {
                       const targetEl = document.querySelector(targetElId);
                       targetEl?.scrollIntoView();
@@ -133,6 +134,14 @@ export const App = () => {
                   }}
                 >
                   {`${interfaceItem.key}`}
+                  {interfaceItem.optional === "true" && (
+                  <Chip
+                    value="Required"
+                    appearance="negative"
+                    className="u-no-margin--bottom"
+                    style={{ marginLeft: '10px' }}
+                  />
+                )}
                 </a>
               </li>
             );

--- a/static/js/src/public/details/integrations/components/InterfaceItem.tsx
+++ b/static/js/src/public/details/integrations/components/InterfaceItem.tsx
@@ -131,7 +131,7 @@ export const InterfaceItem = ({
     <>
       <hr />
       <h3 className="p-heading--4 u-no-margin--bottom" id={interfaceData.key}>
-        <div>
+        <div style={{ display: "flex", alignItems: "center" }}>
           {interfaceData.key}
           <span className="u-text--muted"> endpoint</span>
           {interfaceData.optional && (
@@ -143,7 +143,7 @@ export const InterfaceItem = ({
             />
           )}
         </div>
-        <div style={{ display: "flex", alignItems: "center" }}>
+        <div>
           <a href={`/integrations/${interfaceData.interface}`}>
             {interfaceData.interface}
           </a>

--- a/static/js/src/public/details/integrations/components/InterfaceItem.tsx
+++ b/static/js/src/public/details/integrations/components/InterfaceItem.tsx
@@ -133,7 +133,7 @@ export const InterfaceItem = ({
       <h3 className="p-heading--4 u-no-margin--bottom" id={interfaceData.key}>
         <div style={{ display: "flex", alignItems: "center" }}>
           {interfaceData.key}
-          <span className="u-text--muted"> endpoint</span>
+          <span className="u-text--muted">&nbsp;endpoint</span>
           {interfaceData.optional && (
             <Chip
               value="Required"
@@ -147,7 +147,7 @@ export const InterfaceItem = ({
           <a href={`/integrations/${interfaceData.interface}`}>
             {interfaceData.interface}
           </a>
-          <span className="u-text--muted"> interface </span>
+          <span className="u-text--muted">&nbsp;interface</span>
         </div>
       </h3>
       {interfaceData.description && <p>{interfaceData.description}</p>}

--- a/static/js/src/public/details/integrations/components/InterfaceItem.tsx
+++ b/static/js/src/public/details/integrations/components/InterfaceItem.tsx
@@ -134,7 +134,7 @@ export const InterfaceItem = ({
         <div>
           {interfaceData.key}
           <span className="u-text--muted"> endpoint</span>
-          {interfaceData.optional === "true" && (
+          {interfaceData.optional && (
             <Chip
               value="Required"
               appearance="negative"

--- a/static/js/src/public/details/integrations/components/InterfaceItem.tsx
+++ b/static/js/src/public/details/integrations/components/InterfaceItem.tsx
@@ -143,7 +143,7 @@ export const InterfaceItem = ({
             />
           )}
         </div>
-        <div>
+        <div style={{ display: "flex", alignItems: "center" }}>
           <a href={`/integrations/${interfaceData.interface}`}>
             {interfaceData.interface}
           </a>

--- a/static/js/src/public/details/integrations/components/InterfaceItem.tsx
+++ b/static/js/src/public/details/integrations/components/InterfaceItem.tsx
@@ -134,7 +134,7 @@ export const InterfaceItem = ({
         <div style={{ display: "flex", alignItems: "center" }}>
           {interfaceData.key}
           <span className="u-text--muted">&nbsp;endpoint</span>
-          {interfaceData.optional && (
+          {interfaceData.optional === "true" && (
             <Chip
               value="Required"
               appearance="negative"

--- a/static/js/src/public/details/integrations/components/InterfaceItem.tsx
+++ b/static/js/src/public/details/integrations/components/InterfaceItem.tsx
@@ -134,7 +134,7 @@ export const InterfaceItem = ({
         <div style={{ display: "flex", alignItems: "center" }}>
           {interfaceData.key}
           <span className="u-text--muted">&nbsp;endpoint</span>
-          {interfaceData.optional === "true" && (
+          {interfaceData.required === true && (
             <Chip
               value="Required"
               appearance="negative"

--- a/static/js/src/public/details/integrations/components/InterfaceItem.tsx
+++ b/static/js/src/public/details/integrations/components/InterfaceItem.tsx
@@ -6,7 +6,7 @@ import { useEffect, useMemo } from "react";
 import { useSetRecoilState, useRecoilValue } from "recoil";
 import { useQuery } from "react-query";
 
-import { Row, Col, Spinner } from "@canonical/react-components";
+import { Row, Col, Spinner, Chip } from "@canonical/react-components";
 
 import { filterChipsSelector, filterState } from "../state";
 
@@ -134,6 +134,14 @@ export const InterfaceItem = ({
         <div>
           {interfaceData.key}
           <span className="u-text--muted"> endpoint</span>
+          {interfaceData.optional === "true" && (
+            <Chip
+              value="Required"
+              appearance="negative"
+              className="u-no-margin--bottom"
+              style={{ marginLeft: '10px' }}
+            />
+          )}
         </div>
         <div>
           <a href={`/integrations/${interfaceData.interface}`}>
@@ -149,11 +157,11 @@ export const InterfaceItem = ({
           <div style={{ paddingTop: "0.5rem" }}>
             <p className="u-fixed-width u-no-margin--bottom">
               The <b>{interfaceData.key}</b> endpoint
-              <b>{interfaceType === "requires" ? " requires " : " provides "}</b> 
+              <b>{interfaceType === "requires" ? " requires " : " provides "}</b>
               an integration over the {" "}
               <a href={`/integrations/${interfaceData.interface}`}>
                 {interfaceData.interface}
-              </a> 
+              </a>
               {" "} interface
             </p>
             <p>

--- a/static/js/src/public/details/integrations/components/__tests__/InterfaceItem.test.js
+++ b/static/js/src/public/details/integrations/components/__tests__/InterfaceItem.test.js
@@ -11,13 +11,13 @@ const mockData = {
   key: "test-key",
   interface: "test_interface",
   description: "This is a test description.",
-  optional: true,
+  required: true,
 };
 
 const mockCharmName = "test-charm";
 
 describe("InterfaceItem Component", () => {
-  test("renders with the 'Required' chip when optional is set to true", async () => {
+  test("renders with the 'Required' chip when required is set to true", async () => {
     await act(async () => {
       render(
         <RecoilRoot>
@@ -37,8 +37,8 @@ describe("InterfaceItem Component", () => {
     expect(screen.getByText("Required")).toBeInTheDocument();
   });
 
-  test("renders without the 'Required' chip when optional is set to false", async () => {
-    const dataWithoutOptional = { ...mockData, optional: false };
+  test("renders without the 'Required' chip when required is set to false", async () => {
+    const dataWithoutRequired = { ...mockData, required: false };
 
     await act(async () => {
       render(
@@ -46,7 +46,7 @@ describe("InterfaceItem Component", () => {
           <QueryClientProvider client={queryClient}>
             <InterfaceItem
               interfaceType="provides"
-              interfaceData={dataWithoutOptional}
+              interfaceData={dataWithoutRequired}
               charmName={mockCharmName}
             />
           </QueryClientProvider>

--- a/static/js/src/public/details/integrations/components/__tests__/InterfaceItem.test.js
+++ b/static/js/src/public/details/integrations/components/__tests__/InterfaceItem.test.js
@@ -1,0 +1,61 @@
+import React from "react";
+import { render, screen, act } from "@testing-library/react";
+import { RecoilRoot } from "recoil";
+import { QueryClient, QueryClientProvider } from "react-query";
+import "@testing-library/jest-dom";
+import { InterfaceItem } from "../InterfaceItem";
+
+const queryClient = new QueryClient();
+
+const mockData = {
+  key: "test-key",
+  interface: "test_interface",
+  description: "This is a test description.",
+  optional: true,
+};
+
+const mockCharmName = "test-charm";
+
+describe("InterfaceItem Component", () => {
+  test("renders with the 'Required' chip when optional is set to true", async () => {
+    await act(async () => {
+      render(
+        <RecoilRoot>
+          <QueryClientProvider client={queryClient}>
+            <InterfaceItem
+              interfaceType="provides"
+              interfaceData={mockData}
+              charmName={mockCharmName}
+            />
+          </QueryClientProvider>
+        </RecoilRoot>
+      );
+    });
+
+    expect(screen.getByText("test-key")).toBeInTheDocument();
+    expect(screen.getByText("This is a test description.")).toBeInTheDocument();
+    expect(screen.getByText("Required")).toBeInTheDocument();
+  });
+
+  test("renders without the 'Required' chip when optional is set to false", async () => {
+    const dataWithoutOptional = { ...mockData, optional: false };
+
+    await act(async () => {
+      render(
+        <RecoilRoot>
+          <QueryClientProvider client={queryClient}>
+            <InterfaceItem
+              interfaceType="provides"
+              interfaceData={dataWithoutOptional}
+              charmName={mockCharmName}
+            />
+          </QueryClientProvider>
+        </RecoilRoot>
+      );
+    });
+
+    expect(screen.getByText("test-key")).toBeInTheDocument();
+    expect(screen.getByText("This is a test description.")).toBeInTheDocument();
+    expect(screen.queryByText("Required")).not.toBeInTheDocument();
+  });
+});

--- a/static/js/src/public/details/integrations/types.ts
+++ b/static/js/src/public/details/integrations/types.ts
@@ -3,6 +3,7 @@ export interface IInterfaceData {
   interface: string;
   description: string;
   type?: "provides" | "requires";
+  optional: string;
 }
 
 export interface IFilterChip {

--- a/static/js/src/public/details/integrations/types.ts
+++ b/static/js/src/public/details/integrations/types.ts
@@ -3,7 +3,7 @@ export interface IInterfaceData {
   interface: string;
   description: string;
   type?: "provides" | "requires";
-  optional: string;
+  optional?: "true" | "false";
 }
 
 export interface IFilterChip {

--- a/static/js/src/public/details/integrations/types.ts
+++ b/static/js/src/public/details/integrations/types.ts
@@ -3,7 +3,7 @@ export interface IInterfaceData {
   interface: string;
   description: string;
   type?: "provides" | "requires";
-  optional?: "true" | "false";
+  required?: boolean;
 }
 
 export interface IFilterChip {

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -585,11 +585,11 @@ def details_integrations_data(entity_name):
         .get("relations", {})
     )
 
-    provides = add_optional_fields(
+    provides = add_required_fields(
         package["store_front"]["metadata"].get("provides", {}),
         relations.get("provides", {}),
     )
-    requires = add_optional_fields(
+    requires = add_required_fields(
         package["store_front"]["metadata"].get("requires", {}),
         relations.get("requires", {}),
     )
@@ -602,12 +602,12 @@ def details_integrations_data(entity_name):
     return jsonify({"grouped_relations": grouped_relations})
 
 
-def add_optional_fields(metadata_relations, relations):
+def add_required_fields(metadata_relations, relations):
     processed_relations = [
         {
             **relations[key],
             "key": key,
-            "optional": metadata_relations[key].get("optional", "false"),
+            "required": metadata_relations[key].get("required", False),
         }
         for key in relations.keys()
     ]

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -555,7 +555,10 @@ def details_history(entity_name):
 @redirect_uppercase_to_lowercase
 def details_integrations(entity_name):
     channel_request = request.args.get("channel", default=None, type=str)
-    package = get_package(entity_name, channel_request, FIELDS)
+    extra_fields = [
+        "default-release.revision.metadata-yaml",
+    ]
+    package = get_package(entity_name, channel_request, FIELDS + extra_fields)
 
     return render_template(
         "details/integrations.html",
@@ -571,7 +574,10 @@ def details_integrations(entity_name):
 @redirect_uppercase_to_lowercase
 def details_integrations_data(entity_name):
     channel_request = request.args.get("channel", default=None, type=str)
-    package = get_package(entity_name, channel_request, FIELDS)
+    extra_fields = [
+        "default-release.revision.metadata-yaml",
+    ]
+    package = get_package(entity_name, channel_request, FIELDS + extra_fields)
 
     relations = (
         package.get("default-release", {})
@@ -579,18 +585,31 @@ def details_integrations_data(entity_name):
         .get("relations", {})
     )
 
+    provides = add_optional_fields(
+        package["store_front"]["metadata"].get("provides", {}), relations.get("provides", {})
+    )
+    requires = add_optional_fields(
+        package["store_front"]["metadata"].get("requires", {}), relations.get("requires", {})
+    )
+
     grouped_relations = {
-        "provides": [
-            {**provide[1], "key": provide[0]}
-            for provide in list(relations["provides"].items())
-        ],
-        "requires": [
-            {**require[1], "key": require[0]}
-            for require in list(relations["requires"].items())
-        ],
+        "provides": provides,
+        "requires": requires,
     }
 
     return jsonify({"grouped_relations": grouped_relations})
+
+
+def add_optional_fields(metadata_relations, relations):
+    processed_relations = [
+        {
+            **relations[key],
+            "key": key,
+            "optional": metadata_relations[key].get("optional", False)
+        }
+        for key in relations.keys()
+    ]
+    return processed_relations
 
 
 @store.route('/<regex("' + DETAILS_VIEW_REGEX + '"):entity_name>/resources')

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -586,10 +586,12 @@ def details_integrations_data(entity_name):
     )
 
     provides = add_optional_fields(
-        package["store_front"]["metadata"].get("provides", {}), relations.get("provides", {})
+        package["store_front"]["metadata"].get("provides", {}),
+        relations.get("provides", {})
     )
     requires = add_optional_fields(
-        package["store_front"]["metadata"].get("requires", {}), relations.get("requires", {})
+        package["store_front"]["metadata"].get("requires", {}),
+        relations.get("requires", {})
     )
 
     grouped_relations = {
@@ -605,7 +607,7 @@ def add_optional_fields(metadata_relations, relations):
         {
             **relations[key],
             "key": key,
-            "optional": metadata_relations[key].get("optional", False)
+            "optional": metadata_relations[key].get("optional", False),
         }
         for key in relations.keys()
     ]

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -587,11 +587,11 @@ def details_integrations_data(entity_name):
 
     provides = add_optional_fields(
         package["store_front"]["metadata"].get("provides", {}),
-        relations.get("provides", {})
+        relations.get("provides", {}),
     )
     requires = add_optional_fields(
         package["store_front"]["metadata"].get("requires", {}),
-        relations.get("requires", {})
+        relations.get("requires", {}),
     )
 
     grouped_relations = {

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -607,7 +607,7 @@ def add_optional_fields(metadata_relations, relations):
         {
             **relations[key],
             "key": key,
-            "optional": metadata_relations[key].get("optional", False),
+            "optional": metadata_relations[key].get("optional", "false"),
         }
         for key in relations.keys()
     ]


### PR DESCRIPTION
## Done
- When `required` property in `metadata.yaml` is set to `true`, the `Required` chip will be added to relevant side-nav items and endpoint headings.

## How to QA
- Currently, we don't have `required` property in metadata.yaml but this will be the standard.

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes #https://warthogs.atlassian.net/browse/WD-9928

## Screenshots
<img width="1276" alt="Screenshot 2024-06-14 at 9 32 09 PM" src="https://github.com/canonical/charmhub.io/assets/90341644/5ff30baf-4581-4ab7-9450-470b85fc08ed">

