### PR TITLE
chore: Bump canonicalwebteam.discourse to 5.6.0 and vanilla to 4.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "ts-jest": "29.1.2",
     "ts-loader": "9.5.1",
     "typescript": "5.3.3",
-    "vanilla-framework": "4.9.0",
+    "vanilla-framework": "4.14.0",
     "watch-cli": "0.2.3",
     "webpack": "5.90.1",
     "webpack-cli": "5.1.4"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 canonicalwebteam.flask-base==1.1.0
 beautifulsoup4==4.12.3
 canonicalwebteam.candid==0.9.0
-canonicalwebteam.discourse==5.4.9
+canonicalwebteam.discourse==5.6.0
 canonicalwebteam.image-template==1.3.1
 canonicalwebteam.store-api==4.12.0
 canonicalwebteam.docstring-extractor==1.2.0

--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -1,5 +1,5 @@
 <header id="navigation" class="p-navigation is-dark">
-  <div class="p-navigation__row--25-75">
+  <div class="p-navigation__row">
     <div class="p-navigation__banner">
       <div class="p-navigation__tagged-logo">
         <a class="p-navigation__link" href="https://juju.is">

--- a/yarn.lock
+++ b/yarn.lock
@@ -8709,6 +8709,11 @@ v8-to-istanbul@^9.0.1:
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^2.0.0"
 
+vanilla-framework@4.14.0:
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.14.0.tgz#dca425c806462179467030ac30ef496997e2d8cb"
+  integrity sha512-YctHWwH1SbIltBMMVdeiVW1QtxVjaU15jLKiubgVjE9AByuK/EriyZnPQkXtb/+Rwf1mtF24rae+mmG8aFqUJw==
+
 vanilla-framework@4.9.0:
   version "4.9.0"
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.9.0.tgz#7566b42a22c2394ea1d7ea843d24ec305446cb3e"


### PR DESCRIPTION
## Done

- Bumps canonicalwebteam.discourse to 5.6.0 and vanilla to 4.14.0
- Removes `p-navigation__row--25-75` as "Sign In" / user's account name wrapped onto a new line with the new Vanilla changes

## QA

- Check the changes in Vanilla have not broken anything
- Go to docs (e.g. https://charmhub-io-1864.demos.haus/topics/kubeflow) and hover over a h2 heading, see the [vanilla anchor link](https://vanillaframework.io/docs/patterns/links#anchor-link) works as expected
- Inspect the heading and see there are no trailing numbers on the heading 

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-12941

## Testing
- [X] No testing required (explain why): no logic change
