### PR TITLE
fix: Fix incorrect path names in HTML templates

### DIFF
--- a/templates/base_layout.html
+++ b/templates/base_layout.html
@@ -77,7 +77,7 @@
     <div class="u-hide" id="contact-form-container" data-form-location="/get-in-touch" data-form-id="1337" data-lp-id="2313" data-return-url="http://charmhub.io/thank-you" data-lp-url=""></div>
 
     <script src="{{ versioned_static('js/dist/base.js') }}"></script>
-    <script src="{{ versioned_static('js/dist/navigation-events.ts') }}"></script>
+    <script src="{{ versioned_static('js/dist/navigation-events.js') }}"></script>
 
     <script src="{{url_for('static', filename='js/build/global-nav/global-nav.js')}}"></script>
     <script>

--- a/templates/details/_side-nav.html
+++ b/templates/details/_side-nav.html
@@ -133,4 +133,4 @@
 <p>Share your thoughts on this charm with the community on discourse.</p>
 <p><a class="p-button" href="https://discourse.charmhub.io/">Join the discussion</a></p>
 
-<script src="{{ versioned_static('js/dist/docs-side-nav.ts') }}"></script>
+<script src="{{ versioned_static('js/dist/docs-side-nav.js') }}"></script>

--- a/templates/partial/_header-strip.html
+++ b/templates/partial/_header-strip.html
@@ -10,4 +10,4 @@
   </div>
 </section>
 
-<script src="{{ versioned_static('js/dist/typer.ts') }}" defer></script>
+<script src="{{ versioned_static('js/dist/typer.js') }}" defer></script>

--- a/templates/topics/document.html
+++ b/templates/topics/document.html
@@ -102,5 +102,5 @@
   </div>
 </section>
 
-<script src="{{ versioned_static('js/dist/docs-side-nav.ts') }}"></script>
+<script src="{{ versioned_static('js/dist/docs-side-nav.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Done
Fixes incorrect path names from previous compiler error PRs
- switches back to `js` from `ts`
