### PR TITLE
fix: Tics security fix

### DIFF
--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, patch
 
 from webapp.decorators import redirect_uppercase_to_lowercase
 
+
 class TestDecorators(unittest.TestCase):
     def setUp(self):
         self.mock_get_env = patch("webapp.decorators.os.getenv").start()
@@ -15,9 +16,12 @@ class TestDecorators(unittest.TestCase):
         """
         Test that the decorator redirects the path to lowercase
         """
-        self.mock_flask.request.url.lower.return_value = "http://example.com/test"
+        self.mock_flask.request.url.lower.return_value = (
+            "http://example.com/test"
+        )
         self.mock_flask.abort.return_value = Mock()
         self.mock_get_env.return_value = "devel"
+
         @redirect_uppercase_to_lowercase
         def test_func(entity_name):
             pass
@@ -31,40 +35,52 @@ class TestDecorators(unittest.TestCase):
         """
         Test that the decorator redirects the path to lowercase
         """
-        self.mock_flask.request.url.lower.return_value = "http://localhost:1234/test"
+        self.mock_flask.request.url.lower.return_value = (
+            "http://localhost:1234/test"
+        )
         self.mock_get_env.return_value = "devel"
+
         @redirect_uppercase_to_lowercase
         def test_func(entity_name):
             pass
 
         test_func(entity_name="Test")
-        self.mock_flask.redirect.assert_called_once_with("http://localhost:1234/test")
+        self.mock_flask.redirect.assert_called_once_with(
+            "http://localhost:1234/test"
+        )
 
-        
     def test_redirect_uppercase_to_lowercase_staging(self):
         """
         Test that the decorator redirects the path to lowercase
         """
-        self.mock_flask.request.url.lower.return_value = "https://staging.charmhub.io/test"
+        self.mock_flask.request.url.lower.return_value = (
+            "https://staging.charmhub.io/test"
+        )
         self.mock_get_env.return_value = "staging"
+
         @redirect_uppercase_to_lowercase
         def test_func(entity_name):
             pass
 
         test_func(entity_name="Test")
-        self.mock_flask.redirect.assert_called_once_with("https://staging.charmhub.io/test")
-
+        self.mock_flask.redirect.assert_called_once_with(
+            "https://staging.charmhub.io/test"
+        )
 
     def test_redirect_uppercase_to_lowercase_production(self):
         """
         Test that the decorator redirects the path to lowercase
         """
-        self.mock_flask.request.url.lower.return_value = "https://charmhub.io/test"
+        self.mock_flask.request.url.lower.return_value = (
+            "https://charmhub.io/test"
+        )
         self.mock_get_env.return_value = "production"
+
         @redirect_uppercase_to_lowercase
         def test_func(entity_name):
             pass
 
         test_func(entity_name="Test")
-        self.mock_flask.redirect.assert_called_once_with("https://charmhub.io/test")
-    
+        self.mock_flask.redirect.assert_called_once_with(
+            "https://charmhub.io/test"
+        )

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,0 +1,70 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from webapp.decorators import redirect_uppercase_to_lowercase
+
+class TestDecorators(unittest.TestCase):
+    def setUp(self):
+        self.mock_get_env = patch("webapp.decorators.os.getenv").start()
+        self.mock_flask = patch("webapp.decorators.flask").start()
+
+    def tearDown(self):
+        patch.stopall()
+
+    def test_redirect_uppercase_to_lowercase_random_url(self):
+        """
+        Test that the decorator redirects the path to lowercase
+        """
+        self.mock_flask.request.url.lower.return_value = "http://example.com/test"
+        self.mock_flask.abort.return_value = Mock()
+        self.mock_get_env.return_value = "devel"
+        @redirect_uppercase_to_lowercase
+        def test_func(entity_name):
+            pass
+
+        test_func(entity_name="Test")
+
+        self.assertEqual(self.mock_flask.redirect.called, False)
+        self.assertEqual(self.mock_flask.abort.called, True)
+
+    def test_redirect_uppercase_to_lowercase_localhost(self):
+        """
+        Test that the decorator redirects the path to lowercase
+        """
+        self.mock_flask.request.url.lower.return_value = "http://localhost:1234/test"
+        self.mock_get_env.return_value = "devel"
+        @redirect_uppercase_to_lowercase
+        def test_func(entity_name):
+            pass
+
+        test_func(entity_name="Test")
+        self.mock_flask.redirect.assert_called_once_with("http://localhost:1234/test")
+
+        
+    def test_redirect_uppercase_to_lowercase_staging(self):
+        """
+        Test that the decorator redirects the path to lowercase
+        """
+        self.mock_flask.request.url.lower.return_value = "https://staging.charmhub.io/test"
+        self.mock_get_env.return_value = "staging"
+        @redirect_uppercase_to_lowercase
+        def test_func(entity_name):
+            pass
+
+        test_func(entity_name="Test")
+        self.mock_flask.redirect.assert_called_once_with("https://staging.charmhub.io/test")
+
+
+    def test_redirect_uppercase_to_lowercase_production(self):
+        """
+        Test that the decorator redirects the path to lowercase
+        """
+        self.mock_flask.request.url.lower.return_value = "https://charmhub.io/test"
+        self.mock_get_env.return_value = "production"
+        @redirect_uppercase_to_lowercase
+        def test_func(entity_name):
+            pass
+
+        test_func(entity_name="Test")
+        self.mock_flask.redirect.assert_called_once_with("https://charmhub.io/test")
+    

--- a/webapp/decorators.py
+++ b/webapp/decorators.py
@@ -83,8 +83,18 @@ def redirect_uppercase_to_lowercase(func):
     def is_uppercase(*args, **kwargs):
         name = kwargs["entity_name"]
 
+        ENV = os.getenv("ENVIRONMENT", "devel").strip()
+        redirect = flask.request.url.lower()
+
         if any(char.isupper() for char in name):
-            return flask.redirect(flask.request.url.lower())
+            if (
+                    (ENV == "devel" and redirect.startswith("http://localhost:"))
+                    or
+                    (ENV == "production" and redirect.startswith("https://charmhub.io/"))
+                    or
+                    (ENV == "staging" and redirect.startswith("https://staging.charmhub.io/"))
+                ):
+                return flask.redirect(redirect)
 
         return func(*args, **kwargs)
 

--- a/webapp/decorators.py
+++ b/webapp/decorators.py
@@ -88,12 +88,16 @@ def redirect_uppercase_to_lowercase(func):
 
         if any(char.isupper() for char in name):
             if (
-                    (ENV == "devel" and redirect.startswith("http://localhost:"))
-                    or
-                    (ENV == "production" and redirect.startswith("https://charmhub.io/"))
-                    or
-                    (ENV == "staging" and redirect.startswith("https://staging.charmhub.io/"))
-                ):
+                (ENV == "devel" and redirect.startswith("http://localhost:"))
+                or (
+                    ENV == "production"
+                    and redirect.startswith("https://charmhub.io/")
+                )
+                or (
+                    ENV == "staging"
+                    and redirect.startswith("https://staging.charmhub.io/")
+                )
+            ):
                 return flask.redirect(redirect)
             else:
                 flask.abort(404)

--- a/webapp/decorators.py
+++ b/webapp/decorators.py
@@ -95,6 +95,8 @@ def redirect_uppercase_to_lowercase(func):
                     (ENV == "staging" and redirect.startswith("https://staging.charmhub.io/"))
                 ):
                 return flask.redirect(redirect)
+            else:
+                flask.abort(404)
 
         return func(*args, **kwargs)
 


### PR DESCRIPTION
## Done
- Added more strict checks to internal redirect

## How to QA
- Visit any charm and uppercase the charm name in the url
- Be redirected to the lowercase version
- WON'T WORK ON DEMOS you will get a 404 (which is also expected)

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes #

## Screenshots
