### PR TITLE
chore: Increase code coverage for /static/js/src/base/docs-side-nav.ts

### DIFF
--- a/static/js/src/base/__tests__/docs-side-nav.test.ts
+++ b/static/js/src/base/__tests__/docs-side-nav.test.ts
@@ -1,0 +1,177 @@
+import "@testing-library/jest-dom";
+import {
+  toggleDrawer,
+  setupSideNavigation,
+  setupSideNavigations,
+} from "../docs-side-nav";
+import { fireEvent } from "@testing-library/react";
+
+jest.mock("../docs-side-nav", () => {
+  const docsSideNav = jest.requireActual("../docs-side-nav");
+
+  return {
+    ...docsSideNav,
+    toggleDrawer: jest.fn(docsSideNav.toggleDrawer),
+    setupSideNavigation: jest.fn(docsSideNav.setupSideNavigation),
+    setupSideNavigations: jest.fn(docsSideNav.setupSideNavigations),
+  };
+});
+
+describe("toggleDrawer", () => {
+  let sideNavigation: HTMLElement;
+  let toggleButtonOutsideDrawer: HTMLElement;
+  let toggleButtonInsideDrawer: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+        <div class="p-side-navigation" id="side-navigation">
+          <button class="p-side-navigation__toggle" id="toggle-outside" aria-expanded="false"></button>
+          <div class="p-side-navigation__drawer">
+            <button class="p-side-navigation__toggle--in-drawer" id="toggle-inside" aria-expanded="false"></button>
+          </div>
+        </div>
+      `;
+    sideNavigation = document.getElementById("side-navigation") as HTMLElement;
+    toggleButtonOutsideDrawer = document.getElementById(
+      "toggle-outside"
+    ) as HTMLElement;
+    toggleButtonInsideDrawer = document.getElementById(
+      "toggle-inside"
+    ) as HTMLElement;
+
+    // set initial state of the drawer to be expanded
+    toggleDrawer(sideNavigation, true);
+  });
+
+  it("should expand the drawer", () => {
+    expect(sideNavigation).toHaveClass("is-drawer-expanded");
+    expect(sideNavigation).not.toHaveClass("is-drawer-collapsed");
+    expect(toggleButtonInsideDrawer).toHaveFocus();
+    expect(toggleButtonOutsideDrawer).toHaveAttribute("aria-expanded", "true");
+    expect(toggleButtonInsideDrawer).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("should collapse the drawer", () => {
+    toggleDrawer(sideNavigation, false);
+
+    expect(sideNavigation).toHaveClass("is-drawer-collapsed");
+    expect(sideNavigation).not.toHaveClass("is-drawer-expanded");
+    expect(toggleButtonOutsideDrawer).toHaveFocus();
+    expect(toggleButtonOutsideDrawer).toHaveAttribute("aria-expanded", "false");
+    expect(toggleButtonInsideDrawer).toHaveAttribute("aria-expanded", "false");
+  });
+});
+
+describe("setupSideNavigation", () => {
+  let sideNavigation: HTMLElement;
+  let toggleButtonOutsideDrawer: HTMLElement;
+  let toggleButtonInsideDrawer: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+        <div class="p-side-navigation" id="side-navigation">
+            <button class="js-drawer-toggle p-side-navigation__toggle" id="toggle-outside" aria-expanded="false"></button>
+            <div class="p-side-navigation__drawer">
+            <button class="js-drawer-toggle p-side-navigation__toggle--in-drawer" id="toggle-inside" aria-expanded="false"></button>
+            </div>
+        </div>
+      `;
+    sideNavigation = document.getElementById("side-navigation") as HTMLElement;
+    toggleButtonOutsideDrawer = document.getElementById(
+      "toggle-outside"
+    ) as HTMLElement;
+    toggleButtonInsideDrawer = document.getElementById(
+      "toggle-inside"
+    ) as HTMLElement;
+
+    setupSideNavigation(sideNavigation);
+  });
+
+  it("should initially hide the navigation drawer", () => {
+    expect(sideNavigation).toHaveClass("is-drawer-hidden");
+  });
+
+  it("should expand and collapse the drawer when toggle buttons are clicked", () => {
+    // expand the drawer
+    fireEvent.click(toggleButtonOutsideDrawer);
+
+    expect(sideNavigation).toHaveClass("is-drawer-expanded");
+    expect(sideNavigation).not.toHaveClass("is-drawer-collapsed");
+    expect(sideNavigation).not.toHaveClass("is-drawer-hidden");
+    expect(toggleButtonInsideDrawer).toHaveFocus();
+    expect(toggleButtonOutsideDrawer).toHaveAttribute("aria-expanded", "true");
+    expect(toggleButtonInsideDrawer).toHaveAttribute("aria-expanded", "true");
+
+    // collapse the drawer
+    fireEvent.click(toggleButtonInsideDrawer);
+
+    expect(sideNavigation).toHaveClass("is-drawer-collapsed");
+    expect(sideNavigation).not.toHaveClass("is-drawer-expanded");
+    expect(toggleButtonOutsideDrawer).toHaveFocus();
+    expect(toggleButtonOutsideDrawer).toHaveAttribute("aria-expanded", "false");
+    expect(toggleButtonInsideDrawer).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("should collapse the drawer when the Escape key is pressed", () => {
+    toggleDrawer(sideNavigation, true);
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(sideNavigation).toHaveClass("is-drawer-collapsed");
+    expect(toggleButtonOutsideDrawer).toHaveFocus();
+    expect(toggleButtonOutsideDrawer).toHaveAttribute("aria-expanded", "false");
+    expect(toggleButtonInsideDrawer).toHaveAttribute("aria-expanded", "false");
+  });
+});
+
+describe("setupSideNavigations", () => {
+  let mockSideNavigationElements: HTMLElement[];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    document.body.innerHTML = `
+        <div class="p-side-navigation" id="side-navigation-1">
+          <button class="js-drawer-toggle p-side-navigation__toggle" aria-expanded="false"></button>
+          <div class="p-side-navigation__drawer"></div>
+        </div>
+        <div class="p-side-navigation" id="side-navigation-2">
+          <button class="js-drawer-toggle p-side-navigation__toggle" aria-expanded="false"></button>
+          <div class="p-side-navigation__drawer"></div>
+        </div>
+      `;
+
+    mockSideNavigationElements = Array.from(
+      document.querySelectorAll(".p-side-navigation")
+    ) as HTMLElement[];
+
+    mockSideNavigationElements.forEach((sideNav) => {
+      setupSideNavigation(sideNav);
+    });
+  });
+
+  it("should call setupSideNavigation for each side navigation element", () => {
+    setupSideNavigations(".p-side-navigation");
+    expect(setupSideNavigation).toHaveBeenCalledTimes(2);
+    expect(setupSideNavigation).toHaveBeenCalledWith(
+      mockSideNavigationElements[0]
+    );
+    expect(setupSideNavigation).toHaveBeenCalledWith(
+      mockSideNavigationElements[1]
+    );
+  });
+
+  it("should set up event listeners and initial state for each side navigation element", () => {
+    // first side navigation element
+    const firstSideNav = mockSideNavigationElements[0];
+    expect(firstSideNav).toHaveClass("is-drawer-hidden");
+    fireEvent.click(firstSideNav.querySelector(".js-drawer-toggle")!);
+    expect(firstSideNav).toHaveClass("is-drawer-expanded");
+
+    // second side navigation element
+    const secondSideNav = mockSideNavigationElements[1];
+    expect(secondSideNav).toHaveClass("is-drawer-hidden");
+    fireEvent.click(secondSideNav.querySelector(".js-drawer-toggle")!);
+    expect(secondSideNav).toHaveClass("is-drawer-expanded");
+  });
+});

--- a/static/js/src/base/docs-side-nav.ts
+++ b/static/js/src/base/docs-side-nav.ts
@@ -1,164 +1,174 @@
-(function () {
-  /**
-  Toggles the expanded/collapsed classed on side navigation element.
+/**
+Toggles the expanded/collapsed classed on side navigation element.
 
-  @param {HTMLElement} sideNavigation The side navigation element.
-  @param {Boolean} show Whether to show or hide the drawer.
+@param {HTMLElement} sideNavigation The side navigation element.
+@param {Boolean} show Whether to show or hide the drawer.
 */
-  function toggleDrawer(sideNavigation: HTMLElement, show: boolean) {
-    const toggleButtonOutsideDrawer = sideNavigation.querySelector(
-      ".p-side-navigation__toggle"
-    ) as HTMLElement | null;
-    const toggleButtonInsideDrawer = sideNavigation.querySelector(
-      ".p-side-navigation__toggle--in-drawer"
-    ) as HTMLElement | null;
+export function toggleDrawer(sideNavigation: HTMLElement, show: boolean) {
+  const toggleButtonOutsideDrawer = sideNavigation.querySelector(
+    ".p-side-navigation__toggle"
+  ) as HTMLElement | null;
+  const toggleButtonInsideDrawer = sideNavigation.querySelector(
+    ".p-side-navigation__toggle--in-drawer"
+  ) as HTMLElement | null;
 
-    if (sideNavigation) {
-      if (show) {
-        sideNavigation.classList.remove("is-drawer-collapsed");
-        sideNavigation.classList.add("is-drawer-expanded");
+  if (sideNavigation) {
+    if (show) {
+      sideNavigation.classList.remove("is-drawer-collapsed");
+      sideNavigation.classList.add("is-drawer-expanded");
 
-        toggleButtonInsideDrawer?.focus();
-        toggleButtonOutsideDrawer?.setAttribute("aria-expanded", "true");
-        toggleButtonInsideDrawer?.setAttribute("aria-expanded", "true");
-      } else {
-        sideNavigation.classList.remove("is-drawer-expanded");
-        sideNavigation.classList.add("is-drawer-collapsed");
+      toggleButtonInsideDrawer?.focus();
+      toggleButtonOutsideDrawer?.setAttribute("aria-expanded", "true");
+      toggleButtonInsideDrawer?.setAttribute("aria-expanded", "true");
+    } else {
+      sideNavigation.classList.remove("is-drawer-expanded");
+      sideNavigation.classList.add("is-drawer-collapsed");
 
-        toggleButtonOutsideDrawer?.focus();
-        toggleButtonOutsideDrawer?.setAttribute("aria-expanded", "false");
-        toggleButtonInsideDrawer?.setAttribute("aria-expanded", "false");
-      }
+      toggleButtonOutsideDrawer?.focus();
+      toggleButtonOutsideDrawer?.setAttribute("aria-expanded", "false");
+      toggleButtonInsideDrawer?.setAttribute("aria-expanded", "false");
     }
   }
+}
 
-  // throttle util (for window resize event)
-  const throttle = (fn: Function, delay: number) => {
-    let timer: number | null = null;
-    return function (this: any, ...args: any[]) {
-      const context = this;
-      if (timer) clearTimeout(timer);
-      timer = window.setTimeout(() => {
-        fn.apply(context, args);
-      }, delay);
-    };
+// throttle util (for window resize event)
+export function throttle(fn: Function, delay: number) {
+  let timer: number | null = null;
+  return function (this: any, ...args: any[]) {
+    const context = this;
+    if (timer) clearTimeout(timer);
+    timer = window.setTimeout(() => {
+      fn.apply(context, args);
+    }, delay);
   };
+}
 
-  /**
-    Attaches event listeners for the side navigation toggles
-    @param {HTMLElement} sideNavigation The side navigation element.
-  */
-  function setupSideNavigation(sideNavigation: HTMLElement) {
-    const toggles = Array.from(
-      sideNavigation.querySelectorAll(".js-drawer-toggle")
-    ) as HTMLElement[];
-    const drawerEl = sideNavigation.querySelector(
-      ".p-side-navigation__drawer"
-    ) as HTMLElement | null;
+/**
+  Attaches event listeners for the side navigation toggles
+  @param {HTMLElement} sideNavigation The side navigation element.
+*/
+export function setupSideNavigation(sideNavigation: HTMLElement) {
+  const toggles = Array.from(
+    sideNavigation.querySelectorAll(".js-drawer-toggle")
+  ) as HTMLElement[];
+  const drawerEl = sideNavigation.querySelector(
+    ".p-side-navigation__drawer"
+  ) as HTMLElement | null;
 
-    // hide navigation drawer on small screens
-    sideNavigation.classList.add("is-drawer-hidden");
+  // hide navigation drawer on small screens
+  sideNavigation.classList.add("is-drawer-hidden");
 
-    // setup drawer element
-    drawerEl?.addEventListener("animationend", () => {
-      if (!sideNavigation.classList.contains("is-drawer-expanded")) {
-        sideNavigation.classList.add("is-drawer-hidden");
-      }
-    });
-
-    window.addEventListener("keydown", (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        toggleDrawer(sideNavigation, false);
-      }
-    });
-
-    // setup toggle buttons
-    toggles.forEach((toggle) => {
-      (toggle as HTMLElement).addEventListener("click", (event: MouseEvent) => {
-        event.preventDefault();
-
-        if (sideNavigation) {
-          sideNavigation.classList.remove("is-drawer-hidden");
-          toggleDrawer(
-            sideNavigation,
-            !sideNavigation.classList.contains("is-drawer-expanded")
-          );
-        }
-      });
-    });
-
-    // hide side navigation drawer when screen is resized
-    window.addEventListener(
-      "resize",
-      throttle(() => {
-        toggles.forEach((toggle: Element) => {
-          return toggle.setAttribute("aria-expanded", "false");
-        });
-        // remove expanded/collapsed class names to avoid unexpected animations
-        sideNavigation.classList.remove("is-drawer-expanded");
-        sideNavigation.classList.remove("is-drawer-collapsed");
-        sideNavigation.classList.add("is-drawer-hidden");
-      }, 10)
-    );
-  }
-
-  /**
-    Attaches event listeners for all the side navigations in the document.
-    @param {String} sideNavigationSelector The CSS selector matching side navigation elements.
-  */
-  function setupSideNavigations(sideNavigationSelector: string) {
-    // Setup all side navigations on the page.
-    const sideNavigations = Array.from(
-      document.querySelectorAll(sideNavigationSelector)
-    ) as HTMLElement[];
-
-    sideNavigations.forEach(setupSideNavigation);
-  }
-
-  setupSideNavigations('.p-side-navigation, [class*="p-side-navigation--"]');
-
-  // Setup expandable side navigation
-
-  const expandToggles = document.querySelectorAll(
-    ".p-side-navigation__expand"
-  ) as NodeListOf<HTMLElement>;
-
-  // setup default values of aria-expanded for the toggle button, list title and list itself
-  const setup = (toggle: HTMLElement) => {
-    const isExpanded = toggle.getAttribute("aria-expanded") === "true";
-    if (!isExpanded) {
-      toggle.setAttribute("aria-expanded", "false");
+  // setup drawer element
+  drawerEl?.addEventListener("animationend", () => {
+    if (!sideNavigation.classList.contains("is-drawer-expanded")) {
+      sideNavigation.classList.add("is-drawer-hidden");
     }
-    const item = toggle.closest(".p-side-navigation__item") as HTMLElement | null;
-    const link = item?.querySelector(".p-side-navigation__link") as HTMLElement| null;
-    const nestedList = item?.querySelector(".p-side-navigation__list") as HTMLElement | null;
-    if (!link?.hasAttribute("aria-expanded")) {
-      link?.setAttribute("aria-expanded", isExpanded.toString());
-    }
-    if (!nestedList?.hasAttribute("aria-expanded")) {
-      nestedList?.setAttribute("aria-expanded", isExpanded.toString());
-    }
-  };
+  });
 
-  const handleToggle = (e: Event) => {
-    const item = (e.currentTarget as HTMLElement).closest(".p-side-navigation__item") as HTMLElement | null;
-    const button = item?.querySelector(".p-side-navigation__expand") as HTMLElement | null;
-    const link = item?.querySelector(".p-side-navigation__link") as HTMLElement | null;
-    const nestedList = item?.querySelector(".p-side-navigation__list") as HTMLElement | null;
-    [button, link, nestedList].forEach((el) => {
-      if (el) {
-        el.setAttribute(
-          "aria-expanded",
-          el.getAttribute("aria-expanded") === "true" ? "false" : "true"
+  window.addEventListener("keydown", (e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      toggleDrawer(sideNavigation, false);
+    }
+  });
+
+  // setup toggle buttons
+  toggles.forEach((toggle) => {
+    (toggle as HTMLElement).addEventListener("click", (event: MouseEvent) => {
+      event.preventDefault();
+
+      if (sideNavigation) {
+        sideNavigation.classList.remove("is-drawer-hidden");
+        toggleDrawer(
+          sideNavigation,
+          !sideNavigation.classList.contains("is-drawer-expanded")
         );
       }
     });
-  };
-
-  expandToggles.forEach((toggle) => {
-    setup(toggle);
-    toggle.addEventListener("click", (e) => {
-      handleToggle(e);
-    });
   });
-})();
+
+  // hide side navigation drawer when screen is resized
+  window.addEventListener(
+    "resize",
+    throttle(() => {
+      toggles.forEach((toggle: Element) => {
+        return toggle.setAttribute("aria-expanded", "false");
+      });
+      // remove expanded/collapsed class names to avoid unexpected animations
+      sideNavigation.classList.remove("is-drawer-expanded");
+      sideNavigation.classList.remove("is-drawer-collapsed");
+      sideNavigation.classList.add("is-drawer-hidden");
+    }, 10)
+  );
+}
+
+/**
+  Attaches event listeners for all the side navigations in the document.
+  @param {String} sideNavigationSelector The CSS selector matching side navigation elements.
+*/
+export function setupSideNavigations(sideNavigationSelector: string) {
+  // Setup all side navigations on the page.
+  const sideNavigations = Array.from(
+    document.querySelectorAll(sideNavigationSelector)
+  ) as HTMLElement[];
+
+  sideNavigations.forEach(setupSideNavigation);
+}
+
+setupSideNavigations('.p-side-navigation, [class*="p-side-navigation--"]');
+
+// Setup expandable side navigation
+
+const expandToggles = document.querySelectorAll(
+  ".p-side-navigation__expand"
+) as NodeListOf<HTMLElement>;
+
+// setup default values of aria-expanded for the toggle button, list title and list itself
+const setup = (toggle: HTMLElement) => {
+  const isExpanded = toggle.getAttribute("aria-expanded") === "true";
+  if (!isExpanded) {
+    toggle.setAttribute("aria-expanded", "false");
+  }
+  const item = toggle.closest(".p-side-navigation__item") as HTMLElement | null;
+  const link = item?.querySelector(
+    ".p-side-navigation__link"
+  ) as HTMLElement | null;
+  const nestedList = item?.querySelector(
+    ".p-side-navigation__list"
+  ) as HTMLElement | null;
+  if (!link?.hasAttribute("aria-expanded")) {
+    link?.setAttribute("aria-expanded", isExpanded.toString());
+  }
+  if (!nestedList?.hasAttribute("aria-expanded")) {
+    nestedList?.setAttribute("aria-expanded", isExpanded.toString());
+  }
+};
+
+const handleToggle = (e: Event) => {
+  const item = (e.currentTarget as HTMLElement).closest(
+    ".p-side-navigation__item"
+  ) as HTMLElement | null;
+  const button = item?.querySelector(
+    ".p-side-navigation__expand"
+  ) as HTMLElement | null;
+  const link = item?.querySelector(
+    ".p-side-navigation__link"
+  ) as HTMLElement | null;
+  const nestedList = item?.querySelector(
+    ".p-side-navigation__list"
+  ) as HTMLElement | null;
+  [button, link, nestedList].forEach((el) => {
+    if (el) {
+      el.setAttribute(
+        "aria-expanded",
+        el.getAttribute("aria-expanded") === "true" ? "false" : "true"
+      );
+    }
+  });
+};
+
+expandToggles.forEach((toggle) => {
+  setup(toggle);
+  toggle.addEventListener("click", (e) => {
+    handleToggle(e);
+  });
+});


### PR DESCRIPTION
## Done

- Increases code coverage for /static/js/src/base/docs-side-nav.ts
- Reformats `docs-side-nav.ts` to be an exportable module (there is no logic change in this file)

## How to QA
All tests should pass

## Testing
- [X] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-11614
