### PR TITLE
chore: increase code coverage for static/js/src/public/details/index.ts

### DIFF
--- a/static/js/src/public/details/__tests__/index.test.ts
+++ b/static/js/src/public/details/__tests__/index.test.ts
@@ -1,0 +1,105 @@
+import { init } from "../index";
+import { HistoryState } from "../historyState";
+import { TableOfContents } from "../tableOfContents";
+import { channelMap } from "../channelMap";
+import { act, waitFor } from "@testing-library/react";
+
+jest.mock("../historyState");
+jest.mock("../tableOfContents");
+jest.mock("../channelMap");
+
+describe("index.ts", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    document.body.innerHTML = `
+      <div data-js="configuration"></div>
+      <div data-js="actions">
+        <div role="tab" aria-controls="panel1" aria-expanded="false"></div>
+        <div id="panel1" aria-hidden="true"></div>
+      </div>
+      <div data-js="docs"></div>
+      <div data-js="channel-map"></div>
+    `;
+  });
+
+  test("should initialise TableOfContents with configuration and docs elements", () => {
+    const mockConfigurationEl = document.querySelector(
+      "[data-js='configuration']"
+    ) as HTMLElement;
+    const mockDocsEl = document.querySelector(
+      "[data-js='docs']"
+    ) as HTMLElement;
+
+    init("test-package");
+
+    expect(TableOfContents).toHaveBeenCalledTimes(2);
+    expect(TableOfContents).toHaveBeenCalledWith(
+      mockConfigurationEl,
+      expect.any(HistoryState)
+    );
+    expect(TableOfContents).toHaveBeenCalledWith(
+      mockDocsEl,
+      expect.any(HistoryState)
+    );
+  });
+
+  test("should initialise channelMap with the channel map button", () => {
+    const mockChannelMapButton = document.querySelector(
+      "[data-js='channel-map']"
+    ) as HTMLElement;
+
+    init("test-package");
+
+    expect(channelMap).toHaveBeenCalledWith(
+      "test-package",
+      mockChannelMapButton
+    );
+  });
+
+  test("should toggle accordion correctly and set aria attributes", async () => {
+    const actionButton = document.querySelector("[role='tab']") as HTMLElement;
+    const panel = document.querySelector("#panel1") as HTMLElement;
+
+    init("test-package");
+
+    act(() => {
+      actionButton.click();
+    });
+
+    await waitFor(() => {
+      expect(actionButton.getAttribute("aria-expanded")).toBe("true");
+      expect(panel.getAttribute("aria-hidden")).toBe("false");
+    });
+  });
+
+  test("should handle clicks on action buttons and toggle accordion", () => {
+    const actionButton = document.querySelector("[role='tab']") as HTMLElement;
+    const mockActionsElement = document.querySelector(
+      "[data-js='actions']"
+    ) as HTMLElement;
+
+    jest
+      .spyOn(mockActionsElement, "addEventListener")
+      .mockImplementation(
+        (event: string, listener: EventListenerOrEventListenerObject) => {
+          if (event === "click" && typeof listener === "function") {
+            (listener as Function)({
+              target: actionButton,
+            } as unknown as Event);
+          }
+        }
+      );
+
+    init("test-package");
+
+    expect(mockActionsElement.addEventListener).toHaveBeenCalledWith(
+      "click",
+      expect.any(Function)
+    );
+  });
+
+  test("should initialise HistoryState correctly", () => {
+    init("test-package");
+    expect(HistoryState).toHaveBeenCalled();
+  });
+});

--- a/static/js/src/public/details/index.ts
+++ b/static/js/src/public/details/index.ts
@@ -5,14 +5,15 @@ import { channelMap } from "./channelMap";
 const init = (packageName: string) => {
   const historyState = new HistoryState();
 
-  const configurationEl = document.querySelector<HTMLElement>("[data-js='configuration']");
+  const configurationEl = document.querySelector<HTMLElement>(
+    "[data-js='configuration']"
+  );
   if (configurationEl) {
     new TableOfContents(configurationEl, historyState);
   }
 
   const actions = document.querySelector("[data-js='actions']");
   if (actions) {
-    const actionButtons = actions.querySelectorAll<HTMLElement>("[role='tab']");
     const toggleAccordion = (button: HTMLElement) => {
       const controls = button.parentElement!.querySelector<HTMLElement>(
         `#${button.getAttribute("aria-controls")}`
@@ -26,10 +27,6 @@ const init = (packageName: string) => {
         controls.setAttribute("aria-hidden", (!show).toString());
       }
     };
-
-    actionButtons.forEach((actionButton) => {
-      toggleAccordion(actionButton as HTMLElement);
-    });
 
     actions.addEventListener("click", (e: Event) => {
       let target = e.target as HTMLElement;
@@ -49,7 +46,9 @@ const init = (packageName: string) => {
     new TableOfContents(docsEl, historyState);
   }
 
-  const channelMapButton = document.querySelector<HTMLElement>("[data-js='channel-map']");
+  const channelMapButton = document.querySelector<HTMLElement>(
+    "[data-js='channel-map']"
+  );
   if (channelMapButton) {
     channelMap(packageName, channelMapButton);
   }


### PR DESCRIPTION
## Done
- Adds tests for `static/js/src/public/details/index.ts`
- Modifies `toggleAccordion` logic so that it is not triggered on render, only with user interaction

## How to QA
All tests should pass

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-13210
