### PR TITLE
chore: fix configuration redirect

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -11,7 +11,8 @@ kubeflow-charmers-kubeflow-edge: kubeflow-edge
 openstack-charmers-keystone-saml-mellon: keystone-saml-mellon
 containers-etcd: etcd
 search\??(?P<search>.*)?/?: /?{search}
-/(?P<charm>[A-Za-z0-9-]*[A-Za-z][A-Za-z0-9-]*)/configure: /{charm}/configuration
+/(?P<charm>[A-Za-z0-9-]*[A-Za-z][A-Za-z0-9-]*)/configure: /{charm}/configurations
+/(?P<charm>[A-Za-z0-9-]*[A-Za-z][A-Za-z0-9-]*)/configuration: /{charm}/configurations
 
 jaas: https://jaas.ai/jaas
 docs/stable/about-juju: https://juju.is/about

--- a/templates/details/_details-tab-navigation.html
+++ b/templates/details/_details-tab-navigation.html
@@ -16,7 +16,7 @@
       </li>
       {% endif %}
       <li class="p-tabs__item" role="presentation">
-        <a href="/{{ package.name }}/configuration{% if channel_requested %}?channel={{ channel_requested }}{% endif %}" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'configuration' %}aria-selected="true" {% endif %}>Configuration</a>
+        <a href="/{{ package.name }}/configurations{% if channel_requested %}?channel={{ channel_requested }}{% endif %}" class="p-tabs__link" tabindex="0" role="tab" {% if current_tab == 'configurations' %}aria-selected="true" {% endif %}>Configurations</a>
       </li>
       {% if package.type == "charm" %}
       <li class="p-tabs__item" role="presentation">

--- a/templates/details/configure-bundle.html
+++ b/templates/details/configure-bundle.html
@@ -1,4 +1,4 @@
-{% set current_tab = "configuration" %}
+{% set current_tab = "configurations" %}
 
 {% extends '/details/details_layout.html' %}
 

--- a/templates/details/configure-charm.html
+++ b/templates/details/configure-charm.html
@@ -1,4 +1,4 @@
-{% set current_tab = "configuration" %}
+{% set current_tab = "configurations" %}
 
 {% extends '/details/details_layout.html' %}
 

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -352,12 +352,12 @@ def details_docs(entity_name, path=None):
 
 
 @store.route(
-    '/<regex("' + DETAILS_VIEW_REGEX + '"):entity_name>/configuration'
+    '/<regex("' + DETAILS_VIEW_REGEX + '"):entity_name>/configurations'
 )
 @store.route(
     '/<regex("'
     + DETAILS_VIEW_REGEX
-    + '"):entity_name>/configuration/<path:path>'
+    + '"):entity_name>/configurations/<path:path>'
 )
 @store_maintenance
 @redirect_uppercase_to_lowercase
@@ -378,7 +378,7 @@ def details_configuration(entity_name, path=None):
         if not path and bundle_charms:
             default_charm = bundle_charms[0]
             redirect_url = (
-                f"/{entity_name}/configuration/{default_charm['name']}"
+                f"/{entity_name}/configurations/{default_charm['name']}"
             )
             if channel_request:
                 redirect_url = redirect_url + f"?channel={channel_request}"


### PR DESCRIPTION
## Done
- Changes `Configuration` tab to be `Configurations`
- Changes all routes to be `/configurations`
- Updates redirects to redirect any `configure` / `configuration` to `configurations`
- See [this thread](https://chat.canonical.com/canonical/pl/zi43a1rs3bbomxz4pp5iaxfuuo) for context

## How to QA
- Go to a charm page, check the Configurations tab works as expected
- Try to change the url to `/configure` - it should redirect to `/configurations`
- Try and go to a couple of routes that were broken before and make sure they work:
    - `/ams-lxd/configure#shiftfs_enabled`
    - `/ams/configure#extra_packages`

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): no change in code behaviour

## Issue / Card
Fixes [WD-14169](https://warthogs.atlassian.net/browse/WD-14169)


[WD-14169]: https://warthogs.atlassian.net/browse/WD-14169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ