### PR TITLE
feat: add missing security header

### DIFF
--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -20,13 +20,9 @@ CSP = {
     "img-src": [
         "'self'",
         "data: blob:",
-        "assets.ubuntu.com",
-        "res.cloudinary.com",
-        "api.charmhub.io",
-        "charmhub.io",
-        "*.cdn.snapcraftcontent.com",
-        "www.googletagmanager.com",
-        "stats.g.doubleclick.net",
+        # This is needed to allow images from
+        # https://www.google.*/ads/ga-audiences to load.
+        "*",
     ],
     "script-src-elem": [
         "'self'",


### PR DESCRIPTION
## Done
- Added wildcard to the img-src as it throws error when it tries to fetch an image from https://www.google.*/ads/ga-audiences
## How to QA

- go to [HTTP header analyzer](https://dri.es/headers?url=https%3A%2F%2Fjaas-ai-770.demos.haus%2F)
- verify all the security headers exist.
- go to https://jaas-ai-770.demos.haus/
- Verify all the resources are shown correctly
- Verify there is no behavior change (such as a link doesnt open)

## Testing
- [ ] This PR has tests
- [ ] No testing required (explain why): added csp

## Issue / Card
Fixes[ #14416](https://warthogs.atlassian.net/browse/WD-14416)
