### PR TITLE
chore: Remove grid override

### DIFF
--- a/static/sass/_pattern_p-docstring.scss
+++ b/static/sass/_pattern_p-docstring.scss
@@ -134,19 +134,6 @@
   }
 
   .p-docstring {
-    $grid-x-large-col-prefix: "#{$grid-column-prefix}x-large-" !default;
-
-    @media (min-width: $breakpoint-large) {
-      @for $i from $grid-columns through 1 {
-        // set col-* to span respective number of columns on desktop
-        .#{$grid-x-large-col-prefix}#{$i} {
-          // on large screens provide flex box column implementation for IE
-          // on smaller screens let them display full width one under another
-          @include vf-grid-column($i);
-        }
-      }
-    }
-
     .p-docstring__intro > {
       p:first-child {
         @extend %vf-heading-4;


### PR DESCRIPTION
## Done
Removed a grid override that uses Vanilla variables which will change in the next release, therefore causing build errors. These classes are defined [elsewhere in the codebase](https://github.com/canonical/charmhub.io/blob/main/static/sass/_pattern_grid.scss) so removing this doesn't change anything.

## How to QA
- Go to https://charmhub-io-2012.demos.haus/data-platform-libs/libraries/data_interfaces
- Check that it looks the same as production: https://charmhub.io/data-platform-libs/libraries/data_interfaces

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): Cleanup
