### PR TITLE
fix: Remove By from charm header

### DIFF
--- a/templates/details/_details-header.html
+++ b/templates/details/_details-header.html
@@ -1,62 +1,53 @@
 <div class="p-strip--light is-shallow">
   {% if request.path.startswith("/kubeflow") and schedule_banner("2023-03-08", "2023-03-22") %}
-  {% include "partial/_kubeflow-beta-banner.html" %}
+    {% include "partial/_kubeflow-beta-banner.html" %}
   {% endif %}
   <div class="row">
     <div class="col-9">
       <div class="p-charm-header">
         <div class="p-media-object--large">
           {% if package.type == "charm" %}
-          {% if package["store_front"]["icons"] %}
-          {{
-          image(
-          url=package.store_front.icons[0],
-          alt=package.name,
-          width="100",
-          height="100",
-          hi_def=True,
-          fill=True,
-          attrs={"class": "p-media-object__image"},
-          ) | safe
-          }}
-          {% else %}
-          {{
-          image(
-          url="https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg",
-          alt=package.name,
-          width="100",
-          height="100",
-          hi_def=True,
-          fill=True,
-          attrs={"class": "p-media-object__image"},
-          ) | safe
-          }}
-          {% endif %}
+            {% if package["store_front"]["icons"] %}
+              {{ image(url=package.store_front.icons[0],
+                            alt=package.name,
+                            width="100",
+                            height="100",
+                            hi_def=True,
+                            fill=True,
+                            attrs={"class": "p-media-object__image"},) | safe
+              }}
+            {% else %}
+              {{ image(url="https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg",
+                            alt=package.name,
+                            width="100",
+                            height="100",
+                            hi_def=True,
+                            fill=True,
+                            attrs={"class": "p-media-object__image"},) | safe
+              }}
+            {% endif %}
           {% endif %}
           <div class="p-media-object__details">
-            <h1 class="p-media-object__title">
-              {{ package.store_front["display-name"] }}
-            </h1>
+            <h1 class="p-media-object__title">{{ package.store_front["display-name"] }}</h1>
             <div class="p-media-object__content u-no-margin--bottom">
               <ul class="p-inline-list--middot">
                 <li class="p-inline-list__item">
-                  {% if package.store_front.publisher_name != None %}
-                  {{ package.store_front.publisher_name }}
+                  {% if package.store_front.publisher_name != None %}{{ package.store_front.publisher_name }}{% endif %}
+                  {% if package.type == "bundle" %}
+                    <span class="p-muted-heading u-no-padding" style="font-size: .9rem;">| bundle</span>
                   {% endif %}
-                  {% if package.type == "bundle" %}<span class="p-muted-heading u-no-padding" style="font-size: .9rem;">
-                    | bundle</span>{% endif %}
                   {% if developer_validation == "verified" %}
-                  <span class="p-tooltip--top-center" aria-describedby="openstack-tooltip">
-                    <img src="https://assets.ubuntu.com/v1/75654c90-rosette.svg">
-                    <span class="p-tooltip__message" role="tooltip" id="default-tooltip">Verified account</span>
-                  </span>
+                    <span class="p-tooltip--top-center" aria-describedby="openstack-tooltip">
+                      <img src="https://assets.ubuntu.com/v1/75654c90-rosette.svg">
+                      <span class="p-tooltip__message" role="tooltip" id="default-tooltip">Verified account</span>
+                    </span>
                   {% endif %}
                 </li>
                 {% if package.store_front.categories %}
-                <li class="p-inline-list__item">
-                  <a href="/?filter={{ package.store_front.categories[0].slug }}">{{
+                  <li class="p-inline-list__item">
+                    <a href="/?filter={{ package.store_front.categories[0].slug }}">{{
                     package.store_front.categories[0].name }}</a>
-                </li>
+                  </li>
                 {% endif %}
               </ul>
             </div>
@@ -67,55 +58,61 @@
     </div>
     <div class="col-3">
       <p style="margin-bottom: 0.5rem;">
-        <small class="u-no-padding--top u-text--muted">
-          Platform:
-        </small>
+        <small class="u-no-padding--top u-text--muted">Platform:</small>
       </p>
-
       {% if package.store_front["deployable-on"]|length == 1 and package.store_front["deployable-on"][0] == "kubernetes"
-      %}
-      <div class="series-base">
-        <div class="series-base__title">
-          <img src="https://assets.ubuntu.com/v1/9f8a8273-2018-logo-kubernetes+%282%29.svg" alt="" width="160"
-            height="27" class="p-image--base">
+        %}
+        <div class="series-base">
+          <div class="series-base__title">
+            <img src="https://assets.ubuntu.com/v1/9f8a8273-2018-logo-kubernetes+%282%29.svg"
+                 alt=""
+                 width="160"
+                 height="27"
+                 class="p-image--base">
+          </div>
         </div>
-      </div>
       {% elif package.type == "bundle" and package.store_front.bundle.series %}
-      {# Machine bundles and they have the "series" attribute: we mark them as Ubuntu platform #}
-      <div class="series-base">
-        <div class="series-base__title">
-          <img src="https://assets.ubuntu.com/v1/adac6928-ubuntu.svg" alt="Ubuntu" width="89" height="20"
-            class="p-image--base">
+        {# Machine bundles and they have the "series" attribute: we mark them as Ubuntu platform #}
+        <div class="series-base">
+          <div class="series-base__title">
+            <img src="https://assets.ubuntu.com/v1/adac6928-ubuntu.svg"
+                 alt="Ubuntu"
+                 width="89"
+                 height="20"
+                 class="p-image--base">
+          </div>
         </div>
-      </div>
       {% else %}
-      {% for platform, bases in package.store_front.all_platforms.items() %}
-      <div class="series-base">
-        <div class="series-base__title">
-          {% if platform.startswith("ubuntu") %}
-          <img src="https://assets.ubuntu.com/v1/adac6928-ubuntu.svg" alt="Ubuntu" width="89" height="20"
-            class="p-image--base">
-          {% elif platform.startswith("centos") %}
-          <img src="https://assets.ubuntu.com/v1/fd5cc5d8-CentOS.svg" alt="CentOS" width="85" height="24"
-            class="p-image--base">
-          {% else %}
-          {{ platform }}
-          {% endif %}
-        </div>
-        <div>
-          {% for base in bases | sort(reverse=True) %}
-          {% if loop.index <= 8 %} <span class="series-tag">
-            {{ base }}
-            </span>
-            {% elif loop.index == 9 %}
-            <span class="series-tag">
-              +{{ loop.revindex }}
-            </span>
-            {% endif %}
-            {% endfor %}
-        </div>
-      </div>
-      {% endfor %}
+        {% for platform, bases in package.store_front.all_platforms.items() %}
+          <div class="series-base">
+            <div class="series-base__title">
+              {% if platform.startswith("ubuntu") %}
+                <img src="https://assets.ubuntu.com/v1/adac6928-ubuntu.svg"
+                     alt="Ubuntu"
+                     width="89"
+                     height="20"
+                     class="p-image--base">
+              {% elif platform.startswith("centos") %}
+                <img src="https://assets.ubuntu.com/v1/fd5cc5d8-CentOS.svg"
+                     alt="CentOS"
+                     width="85"
+                     height="24"
+                     class="p-image--base">
+              {% else %}
+                {{ platform }}
+              {% endif %}
+            </div>
+            <div>
+              {% for base in bases | sort(reverse=True) %}
+                {% if loop.index <= 8 %}
+                  <span class="series-tag">{{ base }}</span>
+                {% elif loop.index == 9 %}
+                  <span class="series-tag">+{{ loop.revindex }}</span>
+                {% endif %}
+              {% endfor %}
+            </div>
+          </div>
+        {% endfor %}
       {% endif %}
     </div>
   </div>

--- a/templates/details/_details-header.html
+++ b/templates/details/_details-header.html
@@ -1,37 +1,37 @@
 <div class="p-strip--light is-shallow">
   {% if request.path.startswith("/kubeflow") and schedule_banner("2023-03-08", "2023-03-22") %}
-    {% include "partial/_kubeflow-beta-banner.html" %}
+  {% include "partial/_kubeflow-beta-banner.html" %}
   {% endif %}
   <div class="row">
     <div class="col-9">
       <div class="p-charm-header">
         <div class="p-media-object--large">
           {% if package.type == "charm" %}
-            {% if package["store_front"]["icons"] %}
-              {{
-                image(
-                  url=package.store_front.icons[0],
-                  alt=package.name,
-                  width="100",
-                  height="100",
-                  hi_def=True,
-                  fill=True,
-                  attrs={"class": "p-media-object__image"},
-                ) | safe
-              }}
-            {% else %}
-              {{
-                image(
-                  url="https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg",
-                  alt=package.name,
-                  width="100",
-                  height="100",
-                  hi_def=True,
-                  fill=True,
-                  attrs={"class": "p-media-object__image"},
-                ) | safe
-              }}
-            {% endif %}
+          {% if package["store_front"]["icons"] %}
+          {{
+          image(
+          url=package.store_front.icons[0],
+          alt=package.name,
+          width="100",
+          height="100",
+          hi_def=True,
+          fill=True,
+          attrs={"class": "p-media-object__image"},
+          ) | safe
+          }}
+          {% else %}
+          {{
+          image(
+          url="https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg",
+          alt=package.name,
+          width="100",
+          height="100",
+          hi_def=True,
+          fill=True,
+          attrs={"class": "p-media-object__image"},
+          ) | safe
+          }}
+          {% endif %}
           {% endif %}
           <div class="p-media-object__details">
             <h1 class="p-media-object__title">
@@ -41,9 +41,10 @@
               <ul class="p-inline-list--middot">
                 <li class="p-inline-list__item">
                   {% if package.store_front.publisher_name != None %}
-                    By {{ package.store_front.publisher_name }}
+                  {{ package.store_front.publisher_name }}
                   {% endif %}
-		  {% if package.type == "bundle" %}<span class="p-muted-heading u-no-padding" style="font-size: .9rem;"> | bundle</span>{% endif %}
+                  {% if package.type == "bundle" %}<span class="p-muted-heading u-no-padding" style="font-size: .9rem;">
+                    | bundle</span>{% endif %}
                   {% if developer_validation == "verified" %}
                   <span class="p-tooltip--top-center" aria-describedby="openstack-tooltip">
                     <img src="https://assets.ubuntu.com/v1/75654c90-rosette.svg">
@@ -53,7 +54,8 @@
                 </li>
                 {% if package.store_front.categories %}
                 <li class="p-inline-list__item">
-                  <a href="/?filter={{ package.store_front.categories[0].slug }}">{{ package.store_front.categories[0].name }}</a>
+                  <a href="/?filter={{ package.store_front.categories[0].slug }}">{{
+                    package.store_front.categories[0].name }}</a>
                 </li>
                 {% endif %}
               </ul>
@@ -70,46 +72,50 @@
         </small>
       </p>
 
-      {% if package.store_front["deployable-on"]|length == 1 and package.store_front["deployable-on"][0] == "kubernetes" %}
-        <div class="series-base">
-          <div class="series-base__title">
-            <img src="https://assets.ubuntu.com/v1/9f8a8273-2018-logo-kubernetes+%282%29.svg" alt="" width="160" height="27" class="p-image--base">
-          </div>
+      {% if package.store_front["deployable-on"]|length == 1 and package.store_front["deployable-on"][0] == "kubernetes"
+      %}
+      <div class="series-base">
+        <div class="series-base__title">
+          <img src="https://assets.ubuntu.com/v1/9f8a8273-2018-logo-kubernetes+%282%29.svg" alt="" width="160"
+            height="27" class="p-image--base">
         </div>
+      </div>
       {% elif package.type == "bundle" and package.store_front.bundle.series %}
-        {# Machine bundles and they have the "series" attribute: we mark them as Ubuntu platform #}
-        <div class="series-base">
-          <div class="series-base__title">
-              <img src="https://assets.ubuntu.com/v1/adac6928-ubuntu.svg" alt="Ubuntu" width="89" height="20" class="p-image--base">
-          </div>
+      {# Machine bundles and they have the "series" attribute: we mark them as Ubuntu platform #}
+      <div class="series-base">
+        <div class="series-base__title">
+          <img src="https://assets.ubuntu.com/v1/adac6928-ubuntu.svg" alt="Ubuntu" width="89" height="20"
+            class="p-image--base">
         </div>
+      </div>
       {% else %}
-        {% for platform, bases in package.store_front.all_platforms.items() %}
-              <div class="series-base">
-                <div class="series-base__title">
-                    {% if platform.startswith("ubuntu") %}
-                      <img src="https://assets.ubuntu.com/v1/adac6928-ubuntu.svg" alt="Ubuntu" width="89" height="20" class="p-image--base">
-                    {% elif platform.startswith("centos") %}
-                      <img src="https://assets.ubuntu.com/v1/fd5cc5d8-CentOS.svg" alt="CentOS" width="85" height="24" class="p-image--base">
-                    {% else %}
-                      {{ platform }}
-                    {% endif %}
-                </div>
-                <div>
-                  {% for base in bases | sort(reverse=True)  %}
-                      {% if loop.index <= 8 %}
-                      <span class="series-tag">
-                        {{ base }}
-                      </span>
-                      {% elif loop.index == 9 %}
-                      <span class="series-tag">
-                        +{{ loop.revindex }}
-                      </span>
-                      {% endif %}
-                  {% endfor %}
-                </div>
-              </div>
-        {% endfor %}
+      {% for platform, bases in package.store_front.all_platforms.items() %}
+      <div class="series-base">
+        <div class="series-base__title">
+          {% if platform.startswith("ubuntu") %}
+          <img src="https://assets.ubuntu.com/v1/adac6928-ubuntu.svg" alt="Ubuntu" width="89" height="20"
+            class="p-image--base">
+          {% elif platform.startswith("centos") %}
+          <img src="https://assets.ubuntu.com/v1/fd5cc5d8-CentOS.svg" alt="CentOS" width="85" height="24"
+            class="p-image--base">
+          {% else %}
+          {{ platform }}
+          {% endif %}
+        </div>
+        <div>
+          {% for base in bases | sort(reverse=True) %}
+          {% if loop.index <= 8 %} <span class="series-tag">
+            {{ base }}
+            </span>
+            {% elif loop.index == 9 %}
+            <span class="series-tag">
+              +{{ loop.revindex }}
+            </span>
+            {% endif %}
+            {% endfor %}
+        </div>
+      </div>
+      {% endfor %}
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
## Done
Remove "By" from "By {publisher}" from charm/bundle header

## How to QA
- Visit the demo
- Click on a few charms
- Ensure they don't say "By {publisher}" in the header under the charm name.

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): Simply html chance

