### PR TITLE
Add list of maintainers to side nav

### DIFF
--- a/templates/details/_side-nav.html
+++ b/templates/details/_side-nav.html
@@ -1,6 +1,8 @@
 {% import '/partial/_macros.html' as macros %}
 
+{% set _context = namespace(has_rendered_content=false) %}
 {% if navigation %}
+  {% if _context.has_rendered_content %}<hr class="p-separator--shallow">{% endif %}{% set _context.has_rendered_content = true %}
   {% if versions | length > 1 %}
     <label for="version-select" class="u-hide">Version</label>
     <select name="version-select" id="version-select" onChange="window.location.href=this.value">
@@ -8,7 +10,7 @@
         {% set active = docs_version == version['path'] %}
         <option value="{{ version_paths[version['path']] }}"{% if active %} selected{% endif %}>Version {{ version['version'] }}</option>
       {% endfor %}
-    <select>
+    </select>
   {% endif %}
   <nav data-js="navigation" class="p-side-navigation--raw-html" id="default">
     <a href="#default" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="default">
@@ -29,7 +31,6 @@
       {% endfor %}
     </div>
   </nav>
-  <hr class="p-separator--shallow" />
 {% endif %}
 {#{% if package.result.summary %}
   <h4 class="p-heading--5 u-no-margin--bottom">About</h4>
@@ -65,16 +66,15 @@
       </div>
     </div>
     {% if not package.result.summary %}
-      <hr class="p-separator--shallow">
-    {% endif %}
   {% endif %}
 #}
 {% if package.result.license %}
+  {% if _context.has_rendered_content %}<hr class="p-separator--shallow">{% endif %}{% set _context.has_rendered_content = true %}
   <p><span class="u-text--muted">License</span><br />{{ package.result.license }}</p>
-  <hr class="p-separator--shallow">
 {% endif %}
 
-{% if package.result.website or package.result.repository or package.result.contact or package.result["bugs-url"] %}
+{% if package.result.website or package.result.repository or package.result.contact %}
+  {% if _context.has_rendered_content %}<hr class="p-separator--shallow">{% endif %}{% set _context.has_rendered_content = true %}
   <h4 class="p-heading--5 u-no-margin--bottom">Relevant links</h4>
   <ul class="p-list">
     {% if package.result.website %}
@@ -87,6 +87,39 @@
         <a href="{{ package.result.repository }}"><i class="p-icon--repository"></i>&nbsp;&nbsp;Repository</a>
       </li>
     {% endif %}
+    {% if package.result.contact %}
+      <li class="p-list__item">
+        <a href="{{ package.result.contact }}"><i class="p-icon--contact"></i>&nbsp;&nbsp;Contact</a>
+      </li>
+    {% endif %}
+  </ul>
+{% endif %}
+{% if package.store_front.metadata.maintainers or package.store_front.metadata.issues or package.result['bugs-url'] %}
+  {% if _context.has_rendered_content %}<hr class="p-separator--shallow">{% endif %}{% set _context.has_rendered_content = true %}
+  <h4 class="p-heading--5 u-no-margin--bottom">Contacts</h4>
+  <ul class="p-list">
+    {% if package.store_front.metadata.maintainers %}
+      <h5 class="p-heading--5 p-text--small-caps u-text--muted u-no-margin--bottom">Maintainers</h5>
+      <ul class="p-list" style="margin-bottom: 0.5rem;">
+        {% if package.store_front.metadata.maintainers is iterable and package.store_front.metadata.maintainers is not string %}
+          {% for maintainer in package.store_front.metadata.maintainers %}
+            <li class="p-list__item u-no-margin--bottom">
+              {{ macros.render_maintainer(maintainer) }}
+            </li>
+          {% endfor %}
+        {% else %}
+          <li class="p-list__item u-no-margin--bottom">
+            {% if package.store_front.metadata.maintainers.find('<') != -1 and package.store_front.metadata.maintainers.find('>') != -1 %}
+              {% set name = package.store_front.metadata.maintainers[:package.store_front.metadata.maintainers.find('<')].strip() %}
+              {% set email = package.store_front.metadata.maintainers[package.store_front.metadata.maintainers.find('<') + 1:package.store_front.metadata.maintainers.find('>')].strip() %}
+              <a href="mailto:{{ email }}">
+                <i class="p-icon--user"></i>&nbsp;&nbsp;{{ name }}
+              </a>
+            {% endif %}
+          </li>
+        {% endif %}
+      </ul>
+    {% endif %}
     {% if package["store_front"]["metadata"]["issues"] %}
       <li class="p-list__item">
         <a href="{{ package["store_front"]["metadata"]["issues"][0] }}"><i class="p-icon--bug"></i>&nbsp;&nbsp;Submit a bug</a>
@@ -96,16 +129,14 @@
         <a href="{{ package.result["bugs-url"] }}"><i class="p-icon--bug"></i>&nbsp;&nbsp;Submit a bug</a>
       </li>
     {% endif %}
-    {% if package.result.contact %}
-      <li class="p-list__item">
-        <a href="{{ package.result.contact }}"><i class="p-icon--contact"></i>&nbsp;&nbsp;Contact</a>
-      </li>
-    {% endif %}
   </ul>
-  <hr class="p-separator--shallow" />
 {% endif %}
+{% if _context.has_rendered_content %}<hr class="p-separator--shallow">{% endif %}{% set _context.has_rendered_content = true %}
+<p>Share your thoughts on this charm with the community on discourse.</p>
+<p><a class="p-button" href="https://discourse.charmhub.io/">Join the discussion</a></p>
 <!-- Once `links` is fully ready we can remove the `request.args` check -->
 {% if package["result"]["links"] and request.args.get("show_metadata_links") %}
+  {% if _context.has_rendered_content %}<hr class="p-separator--shallow">{% endif %}{% set _context.has_rendered_content = true %}
   {% if package["result"]["links"]["website"] %}
   <h2 class="p-heading--5 u-no-margin--bottom">Websites</h2>
     <ul class="p-list">
@@ -116,6 +147,7 @@
     <hr class="p-separator--shallow" />
   {% endif %}
   {% if package["result"]["links"]["contact"] %}
+    {% if _context.has_rendered_content %}<hr class="p-separator--shallow">{% endif %}{% set _context.has_rendered_content = true %}
     <h2 class="p-heading--5 u-no-margin--bottom">Contact</h2>
     <ul class="p-list">
       {% for contact in package["result"]["links"]["contact"] %}
@@ -126,11 +158,8 @@
   {% endif %}
 {% endif %}
 {% if not navigation %}
-  <a class="p-button--positive u-no-margin--bottom" href="https://juju.is/docs/sdk/add-docs-to-your-charmhub-page">Add docs to a charm</a>
-  <hr class="p-separator--shallow" />
+  {% if _context.has_rendered_content %}<hr class="p-separator--shallow">{% endif %}{% set _context.has_rendered_content = true %}
+  <a class="p-button--positive" href="https://juju.is/docs/sdk/add-docs-to-your-charmhub-page">Add docs to a charm</a>
 {% endif %}
-<h4 class="p-heading--5 u-no-margin--bottom">Discuss this {{ package.type }}</h4>
-<p>Share your thoughts on this charm with the community on discourse.</p>
-<p><a class="p-button" href="https://discourse.charmhub.io/">Join the discussion</a></p>
 
 <script src="{{ versioned_static('js/dist/docs-side-nav.js') }}"></script>

--- a/templates/partial/_macros.html
+++ b/templates/partial/_macros.html
@@ -30,3 +30,41 @@
     {% endfor %}
   </ul>
 {% endmacro %}
+
+{% macro render_maintainer(maintainer) %}
+  {% if ' <' in maintainer and maintainer.endswith('>') %}
+    {% set name = maintainer.split(' <')[0] %}
+    {% set email = maintainer.split(' <')[1].rstrip('>') %}
+    <a href="mailto:{{ email }}">
+      <i class="p-icon--user"></i>&nbsp;&nbsp;{{ name }}
+    </a>
+  {% elif maintainer is string and maintainer.find('<') != -1 and maintainer.find('>') != -1 %}
+    {% set name = maintainer[:maintainer.find('<')].strip() %}
+    {% set email = maintainer[maintainer.find('<') + 1:maintainer.find('>')].strip() %}
+    <a href="mailto:{{ email }}">
+      <i class="p-icon--user"></i>&nbsp;&nbsp;{{ name }}
+    </a>
+  {% else %}
+    {% if 'matrix.to' in maintainer %}
+      <a href="{{ maintainer }}">
+        <i class="p-icon--user"></i>&nbsp;&nbsp;Matrix Channel
+      </a>
+    {% elif maintainer.startswith('mailto:') %}
+      {% set email = maintainer.split('mailto:')[1] %}
+      <a href="{{ maintainer }}">
+        <i class="p-icon--user"></i>&nbsp;&nbsp;{{ email }}
+      </a>
+    {% elif 'launchpad.net/~' in maintainer %}
+      {% set launchpad_url = maintainer if maintainer.startswith('http') else 'https://' + maintainer %}
+      <a href="{{ launchpad_url }}">
+        <i class="p-icon--user"></i>&nbsp;&nbsp;Launchpad Team
+      </a>
+    {% else %}
+      {% set name = maintainer %}
+      {% set email = maintainer %}
+      <a href="mailto:{{ email }}">
+        <i class="p-icon--user"></i>&nbsp;&nbsp;{{ name }}
+      </a>
+    {% endif %}
+  {% endif %}
+{% endmacro %}


### PR DESCRIPTION
## Done
- Check designs [here](https://www.figma.com/design/bY5HHkqzvYREdxJFhbl5kM/24.04-Charmhub-solution-focus?node-id=98-3492) (frame 87 - did not do "Charm details" or "Upstream product information" sections following discussion with Lukas that there are too many edge cases)
- Adds list of maintainers to side navigation
- Covers edge cases where maintainer is a Matrix channel or Launchpad team
- Moves "Submit a bug" link

## How to QA
- Check design against charms' side navs, specifically the below (but please test many):
    - https://charmhub-io-2040.demos.haus/discourse-k8s
    - https://charmhub-io-2040.demos.haus/vault-k8s
    - https://charmhub-io-2040.demos.haus/grafana-agent-k8s

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): update to jinja template

## Issue / Card
Fixes [WD-4630](https://warthogs.atlassian.net/browse/WD-4630) and [1522](https://github.com/canonical/charmhub.io/issues/1522)


[WD-4630]: https://warthogs.atlassian.net/browse/WD-4630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ