### PR TITLE
fix: highlight active item on integrations side nav

### DIFF
--- a/static/js/src/interfaces/components/InterfaceDetailsNav/InterfaceDetailsNav.tsx
+++ b/static/js/src/interfaces/components/InterfaceDetailsNav/InterfaceDetailsNav.tsx
@@ -1,13 +1,22 @@
+import { useState } from "react";
+
 type Props = {
   hasDeveloperDocumentation: boolean;
 };
 
 function InterfaceDetailsNav({ hasDeveloperDocumentation }: Props) {
+  const [activeLink, setActiveLink] = useState("charms");
   return (
     <div className="p-side-navigation">
       <ul className="p-side-navigation__list">
         <li className="p-side-navigation__item">
-          <a href="#charms" className="p-side-navigation__link is-active">
+          <a
+            href="#charms"
+            className={`p-side-navigation__link ${
+              activeLink === "charms" ? "is-active" : ""
+            }`}
+            onClick={() => setActiveLink("charms")}
+          >
             Charms
           </a>
         </li>
@@ -15,7 +24,10 @@ function InterfaceDetailsNav({ hasDeveloperDocumentation }: Props) {
           <li className="p-side-navigation__item">
             <a
               href="#developer-documentation"
-              className="p-side-navigation__link"
+              className={`p-side-navigation__link ${
+                activeLink === "developer-documentation" ? "is-active" : ""
+              }`}
+              onClick={() => setActiveLink("developer-documentation")}
             >
               Developer documentation
             </a>


### PR DESCRIPTION
## Done
Makes sure active item is selected on the integrations side nav

## How to QA
- Go to https://charmhub-io-2041.demos.haus/integrations/grafana_datasource
- Click on "Developer Documentation"
- Check that Developer Documentation is highlighted in the side nav

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): no behavioural change

## Issue / Card
Fixes [WD-9268](https://warthogs.atlassian.net/browse/WD-9268)


[WD-9268]: https://warthogs.atlassian.net/browse/WD-9268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ