### PR TITLE
chore: upgrade undici package

### DIFF
--- a/jest.polyfills.js
+++ b/jest.polyfills.js
@@ -8,12 +8,18 @@
  * you don't want to deal with this.
  */
 
-const { TextDecoder, TextEncoder, ReadableStream } = require("node:util");
+const {
+  TextDecoder,
+  TextEncoder,
+  ReadableStream,
+  MessagePort,
+} = require("node:util");
 
 Object.defineProperties(globalThis, {
   TextDecoder: { value: TextDecoder },
   TextEncoder: { value: TextEncoder },
   ReadableStream: { value: ReadableStream },
+  MessagePort: { value: MessagePort },
 });
 
 const { Blob, File } = require("node:buffer");

--- a/package.json
+++ b/package.json
@@ -88,6 +88,6 @@
     "stylelint": "16.12.0",
     "stylelint-config-standard-scss": "14.0.0",
     "stylelint-order": "6.0.4",
-    "undici": "6.21.0"
+    "undici": "7.2.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8672,10 +8672,10 @@ undici-types@~6.20.0:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.20.0.tgz#8171bf22c1f588d1554d55bf204bc624af388433"
   integrity sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==
 
-undici@6.21.0:
-  version "6.21.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-6.21.0.tgz#4b3d3afaef984e07b48e7620c34ed8a285ed4cd4"
-  integrity sha512-BUgJXc752Kou3oOIuU1i+yZZypyZRqNPW0vqoMPl8VaoalSfeR0D8/t4iAS3yirs79SSMTxTag+ZC86uswv+Cw==
+undici@7.2.1:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.2.1.tgz#897dc535f78bee62217efc0c5f50ea6b5f078b64"
+  integrity sha512-U2k0XHLJfaciARRxDcqTk2AZQsGXerHzdvfCZcy1hNhSf5KCAF4jIQQxL+apQviOekhRFPqED6Of5/+LcUSLzQ==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
## Done
- Upgrades `unidici`
- Adds a polyfill for `MessagePort`

## How to QA
- Make sure all jobs and tests pass
- Click around the demo to make sure it all looks okay

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why):

## Issue / Card
Splitting up larger [renovate PR](https://github.com/canonical/charmhub.io/pull/2046)