### PR TITLE
chore: update internal dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@babel/preset-typescript": "7.26.0",
     "@canonical/cookie-policy": "3.6.5",
     "@canonical/global-nav": "3.6.4",
-    "@canonical/react-components": "1.7.3",
+    "@canonical/react-components": "1.9.0",
     "@canonical/store-components": "0.52.0",
     "@sentry/react": "8.48.0",
     "@testing-library/dom": "10.4.0",
@@ -61,7 +61,7 @@
     "style-loader": "4.0.0",
     "ts-loader": "9.5.1",
     "typescript": "5.7.2",
-    "vanilla-framework": "4.18.5",
+    "vanilla-framework": "4.19.0",
     "watch-cli": "0.2.3",
     "webpack": "5.97.1",
     "webpack-cli": "6.0.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ canonicalwebteam.flask-base==2.0.0
 beautifulsoup4==4.12.3
 canonicalwebteam.candid==0.9.0
 canonicalwebteam.discourse==5.7.3
-canonicalwebteam.image-template==1.4.1
+canonicalwebteam.image-template==1.4.2
 canonicalwebteam.store-api==5.0.0
 canonicalwebteam.docstring-extractor==1.2.0
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1040,10 +1040,10 @@
     react-table "7.8.0"
     react-useportal "1.0.19"
 
-"@canonical/react-components@1.7.3":
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/@canonical/react-components/-/react-components-1.7.3.tgz#1a5529d0c71a5362edfeee6971324e6feefc1454"
-  integrity sha512-+MxpZdLhHacZzbyN4CJ3YrTtLBD/grcgkhedC6Xp7+xuwwXOJivnIbNxqRbml2k+nEhPRkKpNa1y8e17nlD+nA==
+"@canonical/react-components@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@canonical/react-components/-/react-components-1.9.0.tgz#9337b35e632d7419eddf51823a5243156893185e"
+  integrity sha512-CB2xHvGs/KFsCAbh79pSsJfg+j5Pxmye1qXCeAoirTWj1WIwRiDVV32R07Xys/bAafzINy6kStqJHkq8XUld/g==
   dependencies:
     "@types/jest" "29.5.12"
     "@types/node" "20.16.3"
@@ -8464,10 +8464,10 @@ v8-to-istanbul@^9.0.1:
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^2.0.0"
 
-vanilla-framework@4.18.5:
-  version "4.18.5"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.18.5.tgz#038e3bbeaeca49ae6cf6a074e0ed83901818eae6"
-  integrity sha512-UuYI6se/IV/u9YfzYPIs2FNJapgi9ld7F3s9IbjeR0yCvfH1HCjfZdDPD23tkQDBHiT6wNT6wugXDqFnunVJfQ==
+vanilla-framework@4.19.0:
+  version "4.19.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.19.0.tgz#36fa67a5434ae3222bb83ca04159e87d45ae49a1"
+  integrity sha512-LnB6GdSJHBOVZNlkmEid15tbsweBe1E0T5Mh54KhhUf3JsdLPJSqrUROD/YehZLCHyeEZNDpLnEtaU8YSRz54A==
 
 vanilla-framework@4.9.0:
   version "4.9.0"


### PR DESCRIPTION
## Done
- Updated `@canonical/react-components`, `vanilla-framework` and `canonicalwebteam.image-template`

## How to QA
- All jobs should pass
- Click around the demo to make sure everything works okay

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why):

## Issue / Card
Internal deps - https://github.com/canonical/charmhub.io/pull/2047 (keeping all dependency upgrades in one feature branch)