### PR TITLE
chore: update reserved name alert

### DIFF
--- a/templates/publisher/register-name.html
+++ b/templates/publisher/register-name.html
@@ -29,7 +29,7 @@
     <div class="u-fixed-width">
       <div class="p-notification--negative">
         <p class="p-notification__content" role="status">
-          <span class="p-notification__status">{{ entity_name }} is a reserved name.</span> You can register a new name below or email <a href="mailto:concierge@canonical.com">concierge@canonical.com</a> to request the reserved name.
+          <span class="p-notification__status">{{ entity_name }} is a reserved name.</span> You can register a new name below or <a href="https://discourse.charmhub.io/new-topic?title=Request+reserved+name&category=charmhub+requests">post on the forum</a> to request the reserved name.
         </p>
       </div>
     </div>
@@ -39,7 +39,7 @@
     <div class="u-fixed-width">
       <div class="p-notification--negative">
         <p class="p-notification__content" role="status">
-          <span class="p-notification__status">Another publisher already registered {{ entity_name }}.</span> You can email <a href="mailto:concierge@canonical.com">concierge@canonical.com</a> to file a dispute.
+          <span class="p-notification__status">Another publisher already registered {{ entity_name }}.</span> You can <a href="https://discourse.charmhub.io/new-topic?title=Request+reserved+name&category=charmhub+requests">post on the forum</a> to file a dispute.
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Done
- Update the reserved name alerts as per this discussion: https://chat.canonical.com/canonical/pl/g5yda6gnstnhxxhaux9tshozte 
## How to QA
- login
- request a new charm with a reserved name, (i.e postgresql, test)
- see new warning
- click on link opens a new topic on the forum
## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): copy change

## Issue / Card
Fixes #2058 
