### PR TITLE
chore: Fix handling of SCSS warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "watch-js": "webpack --watch --mode development",
     "watch-scss": "watch -p 'static/sass/**/*.scss' -c 'yarn run build-css'",
     "build": "yarn run build-css && yarn run build-js",
-    "build-css": "sass static/sass/styles.scss:static/css/styles.css static/sass/styles-embedded.scss:static/css/styles-embedded.css --load-path=node_modules --style=compressed --quiet-deps --quiet --silence-deprecation=mixed-decls && postcss --map false --use autoprefixer --replace 'static/css/**/*.css' ",
+    "build-css": "sass static/sass/styles.scss:static/css/styles.css static/sass/styles-embedded.scss:static/css/styles-embedded.css --load-path=node_modules --style=compressed --quiet-deps --silence-deprecation=import && postcss --map false --use autoprefixer --replace 'static/css/**/*.css' ",
     "build-js": "webpack",
     "format-python": "black --line-length 79 webapp",
     "lint-python": "flake8 --extend-ignore=E203 webapp tests && black --check --line-length 79 webapp tests",

--- a/static/sass/_charmhub_p-sort.scss
+++ b/static/sass/_charmhub_p-sort.scss
@@ -1,3 +1,5 @@
+@use "sass:map";
+
 @mixin p-charmhub-sort {
   .p-sort {
     background-color: $color-x-light;
@@ -28,7 +30,7 @@
       background-color: $color-x-light;
       margin-bottom: 0;
       padding:
-        map-get($sp-after, small) - map-get($nudges, nudge--small)
+        map.get($sp-after, small) - map.get($nudges, nudge--small)
         $spv--large;
       position: sticky;
       top: 0;

--- a/static/sass/_charmhub_releases.scss
+++ b/static/sass/_charmhub_releases.scss
@@ -96,7 +96,7 @@
   }
 
   .p-status-label {
-      margin: 0 $sp-small 0 $sp-small;
+      margin: 0 $sp-small;
   }
 
 }

--- a/static/sass/_pattern_l-fluid-breakout.scss
+++ b/static/sass/_pattern_l-fluid-breakout.scss
@@ -1,10 +1,12 @@
+@use "sass:map";
+
 @mixin l-charmhub-fluid-breakout {
   .l-fluid-breakout {
     .l-fluid-breakout__aside {
       .p-muted-heading,
       .p-side-navigation__list {
         @media (max-width: $breakpoint-large - 1px) {
-          padding-inline-start: map-get($grid-margin-widths, small);
+          padding-inline-start: map.get($grid-margin-widths, small);
         }
       }
 

--- a/static/sass/_pattern_p-card.scss
+++ b/static/sass/_pattern_p-card.scss
@@ -97,7 +97,7 @@
     .p-card__content {
       margin-bottom: 0;
       overflow: hidden;
-      padding: 0 $spv--large 0 $spv--large;
+      padding: 0 $spv--large;
       position: relative;
 
       p {

--- a/static/sass/_pattern_p-card.scss
+++ b/static/sass/_pattern_p-card.scss
@@ -25,16 +25,6 @@
   }
 
   .p-card--placeholder {
-    @keyframes shine {
-      0% {
-        background-position: right;
-      }
-
-      100% {
-        background-position: left;
-      }
-    }
-
     animation: shine 3s infinite ease-in-out;
     background-image:
       linear-gradient(
@@ -45,6 +35,16 @@
       );
     background-size: 300% 300%;
     clip-path: url("#animation-mask");
+
+    @keyframes shine {
+      0% {
+        background-position: right;
+      }
+
+      100% {
+        background-position: left;
+      }
+    }
   }
 
   .p-card--button {

--- a/static/sass/_pattern_p-docstring.scss
+++ b/static/sass/_pattern_p-docstring.scss
@@ -1,3 +1,6 @@
+@use "sass:map";
+@use "sass:string";
+
 @mixin p-charmhub-docstring {
   %vf-pseudo-border--top-light {
     @extend %vf-pseudo-border--top;
@@ -52,7 +55,7 @@
   }
 
   %p-code {
-    font-family: unquote($font-monospace);
+    font-family: string.unquote($font-monospace);
     font-weight: $font-weight-regular-text;
   }
 
@@ -148,11 +151,11 @@
   .p-text--dense {
     @extend %default-text;
 
-    margin-bottom: 2 * $sp-unit - map-get($nudges, nudge--p);
+    margin-bottom: 2 * $sp-unit - map.get($nudges, nudge--p);
     margin-top: 0;
 
     @media (min-width: $breakpoint-large) {
-      margin-bottom: 2 * $sp-unit - map-get($nudges, nudge--p);
+      margin-bottom: 2 * $sp-unit - map.get($nudges, nudge--p);
     }
   }
 

--- a/static/sass/_pattern_p-media-object.scss
+++ b/static/sass/_pattern_p-media-object.scss
@@ -22,7 +22,7 @@
 
       .p-button--base {
         font-size: 21px;
-        padding-inline: 0 0;
+        padding-inline: 0;
         text-align: left;
       }
     }

--- a/static/sass/_pattern_p-separator.scss
+++ b/static/sass/_pattern_p-separator.scss
@@ -1,18 +1,18 @@
 @mixin p-charmhub-separator {
   .p-separator--shallow {
-    margin-block: 1.5rem 1.5rem;
+    margin-block: 1.5rem;
   }
 
   .p-separator--medium {
-    margin-block: 3rem 3rem;
+    margin-block: 3rem;
   }
 
   .p-separator--2rem {
-    margin-block: 2rem 2rem;
+    margin-block: 2rem;
   }
 
   .p-separator--deep {
-    margin-block: 4rem 4rem;
+    margin-block: 4rem;
   }
 
   .p-separator--shallower {

--- a/static/sass/_pattern_p-tooltip.scss
+++ b/static/sass/_pattern_p-tooltip.scss
@@ -1,6 +1,8 @@
+@use "sass:map";
+
 @mixin p-charmhub-tooltip {
   .p-tooltip--information {
-    $icon-size: map-get($icon-sizes, default);
+    $icon-size: map.get($icon-sizes, default);
 
     padding-inline-end: $spv--large;
     position: relative;
@@ -32,7 +34,7 @@
 
       @media screen and (max-width: $breakpoint-large - 1) {
         cursor: pointer;
-        line-height: map-get($line-heights, default-text);
+        line-height: map.get($line-heights, default-text);
         margin: 0 0 $spv-nudge-compensation $spv--x-small;
         padding: $spv--x-small;
         text-align: center;

--- a/static/sass/styles-embedded.scss
+++ b/static/sass/styles-embedded.scss
@@ -65,7 +65,7 @@ $color-navigation-background: #252525;
 // make max-width of the layout smaller for embedded view
 .row {
   max-width: 40rem;
-  padding-inline: 1.5rem 1.5rem;
+  padding-inline: 1.5rem;
 }
 
 .p-inline-list--stretch {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -430,6 +430,9 @@ h3 {
   }
 
   .u-equal-height {
+    display: grid;
+    grid-template-columns: repeat(1, 1fr);
+
     @media (min-width: $breakpoint-small) {
       gap: 1.3rem;
       grid-template-columns: repeat(3, 1fr);
@@ -441,9 +444,6 @@ h3 {
         padding-top: 0;
       }
     }
-
-    display: grid;
-    grid-template-columns: repeat(1, 1fr);
   }
 }
 

--- a/webpack.config.rules.js
+++ b/webpack.config.rules.js
@@ -15,7 +15,19 @@ module.exports = [
   },
   {
     test: /\.s[ac]ss$/i,
-    use: ["style-loader", "css-loader", "sass-loader"],
+    use: [
+      "style-loader",
+      "css-loader",
+      {
+        loader: "sass-loader",
+        options: {
+          sassOptions: {
+            quietDeps: true,
+            silenceDeprecations: ["import", "global-builtin", "mixed-decls"],
+          },
+        },
+      },
+    ],
   },
   {
     test: /\.css$/i,


### PR DESCRIPTION
## Done

- updated relevant SCSS files to avoid warnings about global built-in functions and order of declarations
- updated sass command to ignore only import warnings
- updated webpack config to ignore all relevant warnings (to silence react-components and store-components)

Drive by: fixing CSS shorthand values that were failing the linting

## How to QA

- Check CI to see if there are no warnings from Sass
- or locally run `dotrun build`

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): only build changes

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-18330

Follow up to: https://github.com/canonical/snapcraft.io/pull/4988

