### PR TITLE
Re-introduce 25/75 split in the top navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "style-loader": "4.0.0",
     "ts-loader": "9.5.1",
     "typescript": "5.7.2",
-    "vanilla-framework": "4.19.0",
+    "vanilla-framework": "4.20.3",
     "watch-cli": "0.2.3",
     "webpack": "5.97.1",
     "webpack-cli": "6.0.1"

--- a/static/js/src/base/global-nav.ts
+++ b/static/js/src/base/global-nav.ts
@@ -1,5 +1,5 @@
 import { createNav } from "@canonical/global-nav";
 
 createNav({
-  breakpoint: 1110, // keep it in sync with $breakpoint-navigation-threshold in styles.scss
+  breakpoint: 1220, // keep it in sync with $breakpoint-navigation-threshold in styles.scss
 });

--- a/static/js/src/base/global-nav.ts
+++ b/static/js/src/base/global-nav.ts
@@ -1,5 +1,5 @@
 import { createNav } from "@canonical/global-nav";
 
 createNav({
-  breakpoint: 1110,
+  breakpoint: 1110, // keep it in sync with $breakpoint-navigation-threshold in styles.scss
 });

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -2,7 +2,7 @@
 
 $brand-color: #772953;
 $color-text-orange: #d54110;
-$breakpoint-large: 1220px;
+$breakpoint-navigation-threshold: 1110px; // keep it in sync with juju.is and breakpoint value in global-nav.ts
 
 // import cookie policy
 @import "@canonical/cookie-policy/build/css/cookie-policy";

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -2,7 +2,7 @@
 
 $brand-color: #772953;
 $color-text-orange: #d54110;
-$breakpoint-navigation-threshold: 1110px; // keep it in sync with juju.is and breakpoint value in global-nav.ts
+$breakpoint-navigation-threshold: 1220px; // keep it in sync with juju.is and breakpoint value in global-nav.ts
 
 // import cookie policy
 @import "@canonical/cookie-policy/build/css/cookie-policy";

--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -1,5 +1,5 @@
 <header id="navigation" class="p-navigation is-dark">
-  <div class="p-navigation__row">
+  <div class="p-navigation__row--25-75">
     <div class="p-navigation__banner">
       <div class="p-navigation__tagged-logo">
         <a class="p-navigation__link" href="https://juju.is">

--- a/yarn.lock
+++ b/yarn.lock
@@ -8464,10 +8464,10 @@ v8-to-istanbul@^9.0.1:
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^2.0.0"
 
-vanilla-framework@4.19.0:
-  version "4.19.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.19.0.tgz#36fa67a5434ae3222bb83ca04159e87d45ae49a1"
-  integrity sha512-LnB6GdSJHBOVZNlkmEid15tbsweBe1E0T5Mh54KhhUf3JsdLPJSqrUROD/YehZLCHyeEZNDpLnEtaU8YSRz54A==
+vanilla-framework@4.20.3:
+  version "4.20.3"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.20.3.tgz#a306e80f32f5c6b6f107c02e64cc642c6eb32148"
+  integrity sha512-8nE8BxHRckdjo8VYW0jVLK9JMz1XAoTZcKGweg0jM8cV+/D313pPyomEeODAD1qq66yf/W0RfHTXv/wp0AaYfQ==
 
 vanilla-framework@4.9.0:
   version "4.9.0"


### PR DESCRIPTION
## Done

- re-introduces the 25/75 split in top navigation
- Updates the navigation breakpoints to align with juju.is (https://github.com/canonical/juju.is/pull/567)
- Makes sure top navigation and global-nav breakpoints are the same
- Updates Vanilla to latest version

## How to QA

- open demo https://charmhub-io-2067.demos.haus/
- make sure top navigation items are aligned with 75% layout of hero below
- resize screen, make sure navigation works as expected without overflowing or wrapping
- check "All Canonical" menu, make sure it switches between mobile and desktop view at the same time as top navigation 
- check juju.is from this [PR](https://github.com/canonical/juju.is/pull/567) and [demo](https://juju-is-567.demos.haus/), make sure the navigations are consistent

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): just visual style adjustments

## Issue / Card
Fixes WD-18722

## Screenshots

<img width="1229" alt="image" src="https://github.com/user-attachments/assets/1ee5fdf4-3a3a-49ef-9577-bd4dbcd46124" />
