### PR TITLE
Update nav bar - remove juju and sdk links

### DIFF
--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -42,16 +42,8 @@
             </li>
           </ul>
         </li>
-        <li class="p-navigation__item--dropdown-toggle" id="docs-link">
-          <a class="p-navigation__link" href="#docs-link-menu" aria-controls="docs-link-menu">Docs</a>
-          <ul class="p-navigation__dropdown" id="docs-link-menu" aria-hidden="true">
-            <li>
-              <a class="p-navigation__dropdown-item" href="https://juju.is/docs/juju">Juju</a>
-            </li>
-            <li>
-              <a class="p-navigation__dropdown-item" href="https://juju.is/docs/sdk">Charm SDK</a>
-            </li>
-          </ul>
+        <li class="p-navigation__item">
+          <a class="p-navigation__link" href="https://juju.is/docs">Docs</a>
         </li>
         <li class="p-navigation__item">
           <a class="p-navigation__link" href="https://ubuntu.com/blog/tag/juju">Blog</a>


### PR DESCRIPTION
## Done
- Removes juju and sdk links from Docs dropdown in nav bar to match juju.is nav bar

## How to QA
- Check demo
- Make sure `Docs` link in nav bar is a single link (no dropdown) and goes to juju.is/docs

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): no behavioural change
