### PR TITLE
upgrade canonical/store-components

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@canonical/cookie-policy": "3.6.5",
     "@canonical/global-nav": "3.6.4",
     "@canonical/react-components": "2.1.0",
-    "@canonical/store-components": "0.52.0",
+    "@canonical/store-components": "0.53.0",
     "@sentry/react": "8.48.0",
     "@testing-library/dom": "10.4.0",
     "@testing-library/jest-dom": "6.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1045,10 +1045,10 @@
   dependencies:
     vanilla-framework "4.9.0"
 
-"@canonical/react-components@1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@canonical/react-components/-/react-components-1.7.0.tgz#e1863b92a0115e9a1d64d894b32197cb4b19b912"
-  integrity sha512-L+H99qfv6lIpHDfiMLQutN7VPYBCyu8SezWvOkomfixL4OsdFPw0Whr92l85p553BN9FyXjtEyqX8s+D1U0JlQ==
+"@canonical/react-components@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@canonical/react-components/-/react-components-1.9.0.tgz#9337b35e632d7419eddf51823a5243156893185e"
+  integrity sha512-CB2xHvGs/KFsCAbh79pSsJfg+j5Pxmye1qXCeAoirTWj1WIwRiDVV32R07Xys/bAafzINy6kStqJHkq8XUld/g==
   dependencies:
     "@types/jest" "29.5.12"
     "@types/node" "20.16.3"
@@ -1078,20 +1078,20 @@
     prop-types "15.8.1"
     react-table "7.8.0"
 
-"@canonical/store-components@0.52.0":
-  version "0.52.0"
-  resolved "https://registry.yarnpkg.com/@canonical/store-components/-/store-components-0.52.0.tgz#04415a5c826601feb9cb554a1e5086c874b83ef6"
-  integrity sha512-VlUgr3l0pdlfYp/TTifSIjrqeftdu9t5jetN8NBPwtGAm30N45Evr++27oZDGQ1nNVW7LS2S7CY60Zp9H9qviw==
+"@canonical/store-components@0.53.0":
+  version "0.53.0"
+  resolved "https://registry.yarnpkg.com/@canonical/store-components/-/store-components-0.53.0.tgz#f2180571ec364cbd6854b8038c11f4c8dffdc558"
+  integrity sha512-2rSkfn5aIQAhMuzJyE3eg8dQptnk2/1oLaUg/wCpk0UtnWy6jISAZ1sLYSr3AFIx2z1nqG+7VbTG6FbjcFFIDQ==
   dependencies:
-    "@canonical/react-components" "1.7.0"
+    "@canonical/react-components" "1.9.0"
     "@types/jest" "27.5.2"
-    "@types/node" "18.19.55"
+    "@types/node" "18.19.71"
     "@types/react" "17.0.83"
-    "@types/react-dom" "17.0.25"
+    "@types/react-dom" "17.0.26"
     "@types/react-table" "7.7.20"
     classnames "2.5.1"
     formik "2.4.6"
-    nanoid "5.0.7"
+    nanoid "5.0.9"
     prop-types "15.8.1"
     react-table "7.8.0"
     react-useportal "1.0.19"
@@ -2184,10 +2184,10 @@
   dependencies:
     undici-types "~6.20.0"
 
-"@types/node@18.19.55":
-  version "18.19.55"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.55.tgz#29c3f8e1485a92ec96636957ddec55aabc6e856e"
-  integrity sha512-zzw5Vw52205Zr/nmErSEkN5FLqXPuKX/k5d1D7RKHATGqU7y6YfX9QxZraUzUrFGqH6XzOzG196BC35ltJC4Cw==
+"@types/node@18.19.71":
+  version "18.19.71"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.71.tgz#96d4f0a0be735ead6c8998c62a4b2c0012a5d09a"
+  integrity sha512-evXpcgtZm8FY4jqBSN8+DmOTcVkkvTmAayeo4Wf3m1xAruyVGzGuDh/Fb/WWX2yLItUiho42ozyJjB0dw//Tkw==
   dependencies:
     undici-types "~5.26.4"
 
@@ -2210,7 +2210,7 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.14.tgz#1433419d73b2a7ebfc6918dcefd2ec0d5cd698f2"
   integrity sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==
 
-"@types/react-dom@17.0.25", "@types/react-dom@18.3.0", "@types/react-dom@18.3.5", "@types/react-dom@19.0.3":
+"@types/react-dom@17.0.26", "@types/react-dom@18.3.0", "@types/react-dom@18.3.5", "@types/react-dom@19.0.3":
   version "18.3.5"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.5.tgz#45f9f87398c5dcea085b715c58ddcf1faf65f716"
   integrity sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==
@@ -6584,10 +6584,10 @@ nano-time@1.0.0:
   dependencies:
     big-integer "^1.6.16"
 
-nanoid@5.0.7:
-  version "5.0.7"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-5.0.7.tgz#6452e8c5a816861fd9d2b898399f7e5fd6944cc6"
-  integrity sha512-oLxFY2gd2IqnjcYyOXD8XGCftpGtZP2AbHbOkthDkvRywH5ayNtPVy9YlOPcHckXzbLTCHpkb7FB+yuxKV13pQ==
+nanoid@5.0.9:
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-5.0.9.tgz#977dcbaac055430ce7b1e19cf0130cea91a20e50"
+  integrity sha512-Aooyr6MXU6HpvvWXKoVoXwKMs/KyVakWwg7xQfv5/S/RIgJMy0Ifa45H9qqYy7pTCszrHzP21Uk4PZq2HpEM8Q==
 
 nanoid@^3.3.8:
   version "3.3.8"


### PR DESCRIPTION
## Done
- Bumps `canonical/store-components` version
- Upgrading one package at a time from [this PR](https://github.com/canonical/charmhub.io/pull/2047) to try and pin point the demo issue

## How to QA
- Check the demo to make sure everything looks the same

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): no change in behaviour
