### PR TITLE
chore: remove application layout on publicise section

### DIFF
--- a/static/js/src/publisher-admin/pages/Collaboration/Collaboration.tsx
+++ b/static/js/src/publisher-admin/pages/Collaboration/Collaboration.tsx
@@ -90,74 +90,75 @@ function Collaboration() {
   return (
     <>
       <div className="l-application">
-        {showRevokeSuccess && (
-          <Notification
-            severity="positive"
-            onDismiss={() => {
-              setShowRevokeSuccess(false);
-            }}
-          >
-            The invite for <strong>{activeInviteEmail}</strong> has been
-            revoked.
-          </Notification>
-        )}
-
-        {showRevokeError && (
-          <Notification
-            severity="negative"
-            onDismiss={() => {
-              setShowRevokeError(false);
-            }}
-          >
-            There was a problem revoking the invite for{" "}
-            <strong>{activeInviteEmail}</strong>.
-          </Notification>
-        )}
-
-        {showInviteSuccess && (
-          <Notification
-            severity="positive"
-            title="An invite has been created"
-            onDismiss={() => {
-              setShowInviteSuccess(false);
-            }}
-          >
-            <p>
-              <a target="_blank" href={inviteEmailLink} rel="noreferrer">
-                Send the invite by email
-              </a>{" "}
-              or copy link:
-            </p>
-            <div>
-              <input
-                className="u-no-margin--bottom"
-                type="text"
-                readOnly
-                value={inviteLink}
-                style={{
-                  color: "inherit",
-                }}
-                onFocus={(e) => {
-                  e.target.select();
-                }}
-              />
-            </div>
-          </Notification>
-        )}
-
-        {showInviteError && (
-          <Notification
-            severity="negative"
-            onDismiss={() => {
-              setShowInviteError(false);
-            }}
-          >
-            There was a problem creating an invite for{" "}
-            <strong>{activeInviteEmail}</strong>.
-          </Notification>
-        )}
         <div className="l-main">
           <div className="p-panel">
+            {showRevokeSuccess && (
+              <Notification
+                severity="positive"
+                onDismiss={() => {
+                  setShowRevokeSuccess(false);
+                }}
+              >
+                The invite for <strong>{activeInviteEmail}</strong> has been
+                revoked.
+              </Notification>
+            )}
+
+            {showRevokeError && (
+              <Notification
+                severity="negative"
+                onDismiss={() => {
+                  setShowRevokeError(false);
+                }}
+              >
+                There was a problem revoking the invite for{" "}
+                <strong>{activeInviteEmail}</strong>.
+              </Notification>
+            )}
+
+            {showInviteSuccess && (
+              <Notification
+                severity="positive"
+                title="An invite has been created"
+                onDismiss={() => {
+                  setShowInviteSuccess(false);
+                }}
+              >
+                <p>
+                  <a target="_blank" href={inviteEmailLink} rel="noreferrer">
+                    Send the invite by email
+                  </a>{" "}
+                  or copy link:
+                </p>
+                <div>
+                  <input
+                    className="u-no-margin--bottom"
+                    type="text"
+                    readOnly
+                    value={inviteLink}
+                    style={{
+                      color: "inherit",
+                    }}
+                    onFocus={(e) => {
+                      e.target.select();
+                    }}
+                  />
+                </div>
+              </Notification>
+            )}
+
+            {showInviteError && (
+              <Notification
+                severity="negative"
+                onDismiss={() => {
+                  setShowInviteError(false);
+                }}
+              >
+                There was a problem creating an invite for{" "}
+                <strong>{activeInviteEmail}</strong>.
+              </Notification>
+            )}
+
             <Row>
               <Col size={6}>
                 <CollaboratorFilter />

--- a/static/js/src/publisher-admin/pages/Collaboration/Collaboration.tsx
+++ b/static/js/src/publisher-admin/pages/Collaboration/Collaboration.tsx
@@ -89,7 +89,7 @@ function Collaboration() {
 
   return (
     <>
-      <div className="u-fixed-width">
+      <div className="l-application">
         {showRevokeSuccess && (
           <Notification
             severity="positive"
@@ -156,112 +156,116 @@ function Collaboration() {
             <strong>{activeInviteEmail}</strong>.
           </Notification>
         )}
-      </div>
-      <Row>
-        <Col size={6}>
-          <CollaboratorFilter />
-        </Col>
-        <Col size={6} className="u-align--right">
-          <Button
-            appearance="positive"
-            hasIcon
-            onClick={() => {
-              setShowSidePanel(true);
-            }}
-          >
-            <Icon name="plus" light />
-            <span>Add new collaborator</span>
-          </Button>
-        </Col>
-      </Row>
-      <Strip shallow>
-        <div className="u-fixed-width">
-          <Accordion
-            expanded="collaborators"
-            sections={[
-              {
-                key: "collaborators",
-                title: `Active shares (${getCollaboratorsCount()})`,
-                content: (
-                  <Collaborators
-                    setShowRevokeModal={setShowRevokeCollaboratorModal}
-                  />
-                ),
-              },
-              {
-                key: "invites",
-                title: `Invites (${invitesList.length})`,
-                content: (
-                  <Invites
-                    setShowRevokeModal={setShowRevokeInviteModal}
-                    setShowReopenModal={setShowReopenInviteModal}
-                    setShowResendModal={setShowResendInviteModal}
-                  />
-                ),
-              },
-            ]}
-          />
+        <div className="l-main">
+          <div className="p-panel">
+            <Row>
+              <Col size={6}>
+                <CollaboratorFilter />
+              </Col>
+              <Col size={6} className="u-align--right">
+                <Button
+                  appearance="positive"
+                  hasIcon
+                  onClick={() => {
+                    setShowSidePanel(true);
+                  }}
+                >
+                  <Icon name="plus" light />
+                  <span>Add new collaborator</span>
+                </Button>
+              </Col>
+            </Row>
+            <Strip shallow>
+              <div className="u-fixed-width">
+                <Accordion
+                  expanded="collaborators"
+                  sections={[
+                    {
+                      key: "collaborators",
+                      title: `Active shares (${getCollaboratorsCount()})`,
+                      content: (
+                        <Collaborators
+                          setShowRevokeModal={setShowRevokeCollaboratorModal}
+                        />
+                      ),
+                    },
+                    {
+                      key: "invites",
+                      title: `Invites (${invitesList.length})`,
+                      content: (
+                        <Invites
+                          setShowRevokeModal={setShowRevokeInviteModal}
+                          setShowReopenModal={setShowReopenInviteModal}
+                          setShowResendModal={setShowResendInviteModal}
+                        />
+                      ),
+                    },
+                  ]}
+                />
+              </div>
+            </Strip>
+          </div>
         </div>
-      </Strip>
-      <div
-        className={`l-aside__overlay ${!showSidePanel && "u-hide"}`}
-        onClick={() => {
-          setShowSidePanel(false);
-        }}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" || e.key === "Escape") {
+        <div
+          className={`l-aside__overlay ${!showSidePanel && "u-hide"}`}
+          onClick={() => {
             setShowSidePanel(false);
-          }
-        }}
-        role="button"
-        tabIndex={0}
-        aria-label="Close side panel"
-      ></div>
-      <aside className={`l-aside ${!showSidePanel && "is-collapsed"}`}>
-        <InviteCollaborator
-          setShowSidePanel={setShowSidePanel}
-          setShowInviteSuccess={setShowInviteSuccess}
-          setShowInviteError={setShowInviteError}
-        />
-      </aside>
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === "Escape") {
+              setShowSidePanel(false);
+            }
+          }}
+          role="button"
+          tabIndex={0}
+          aria-label="Close side panel"
+        ></div>
+        <aside className={`l-aside ${!showSidePanel && "is-collapsed"}`}>
+          <InviteCollaborator
+            setShowSidePanel={setShowSidePanel}
+            setShowInviteSuccess={setShowInviteSuccess}
+            setShowInviteError={setShowInviteError}
+          />
+        </aside>
 
-      {showRevokeCollaboratorModal && (
-        <InviteConfirmationModal
-          action="Revoke"
-          setShowModal={setShowRevokeCollaboratorModal}
-          setShowSuccess={setShowRevokeSuccess}
-          setShowError={setShowRevokeError}
-          queryKey="collaboratorsData"
-        />
-      )}
+        {showRevokeCollaboratorModal && (
+          <InviteConfirmationModal
+            action="Revoke"
+            setShowModal={setShowRevokeCollaboratorModal}
+            setShowSuccess={setShowRevokeSuccess}
+            setShowError={setShowRevokeError}
+            queryKey="collaboratorsData"
+          />
+        )}
 
-      {showRevokeInviteModal && (
-        <InviteConfirmationModal
-          action="Revoke"
-          setShowModal={setShowRevokeInviteModal}
-          setShowSuccess={setShowRevokeSuccess}
-          setShowError={setShowRevokeError}
-          queryKey="invitesData"
-        />
-      )}
+        {showRevokeInviteModal && (
+          <InviteConfirmationModal
+            action="Revoke"
+            setShowModal={setShowRevokeInviteModal}
+            setShowSuccess={setShowRevokeSuccess}
+            setShowError={setShowRevokeError}
+            queryKey="invitesData"
+          />
+        )}
 
-      {showReopenInviteModal && (
-        <InviteConfirmationModal
-          action="Reopen"
-          setShowModal={setShowReopenInviteModal}
-          setShowSuccess={setShowInviteSuccess}
-          setShowError={setShowInviteError}
-        />
-      )}
+        {showReopenInviteModal && (
+          <InviteConfirmationModal
+            action="Reopen"
+            setShowModal={setShowReopenInviteModal}
+            setShowSuccess={setShowInviteSuccess}
+            setShowError={setShowInviteError}
+          />
+        )}
 
-      {showResendInviteModal && (
-        <InviteConfirmationModal
-          action="Resend"
-          setShowModal={setShowResendInviteModal}
-          setShowSuccess={setShowInviteSuccess}
-          setShowError={setShowInviteError}
-        />
-      )}
+        {showResendInviteModal && (
+          <InviteConfirmationModal
+            action="Resend"
+            setShowModal={setShowResendInviteModal}
+            setShowSuccess={setShowInviteSuccess}
+            setShowError={setShowInviteError}
+          />
+        )}
+      </div>
     </>
   );
 }

--- a/static/js/src/publisher-admin/routes/root.tsx
+++ b/static/js/src/publisher-admin/routes/root.tsx
@@ -22,17 +22,9 @@ function Root() {
   return (
     <>
       <SectionHeader />
-      <div className="l-application">
-        <div className="l-main">
-          <div className="p-panel">
-            <div className="p-panel__content">
-              <div className="u-fixed-width">
-                <SectionNav />
-                <Outlet />
-              </div>
-            </div>
-          </div>
-        </div>
+      <div className="u-fixed-width">
+        <SectionNav />
+        <Outlet />
       </div>
     </>
   );


### PR DESCRIPTION
## Done
- Removes application layout in `Publicise` tab of a package as it was redundant and causing layout issues

## How to QA
- Go to the Publicise tab on a charm/bundle that you are a collaborator on
  - e.g. https://charmhub-io-2082.demos.haus/landscape-keystone/publicise
- Check all content is visible on all sections (buttons, badges and embedded cards)
  - also check on different screen sizes (at the moment, content is getting cut off on my 13" laptop on Chrome)

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): no change in behaviour

## Issue / Card
Fixes [WD-19293](https://warthogs.atlassian.net/browse/WD-19293)


[WD-19293]: https://warthogs.atlassian.net/browse/WD-19293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ