### PR TITLE
Fix cross site scripting errors

### DIFF
--- a/static/js/src/public/store-details/packages.ts
+++ b/static/js/src/public/store-details/packages.ts
@@ -281,13 +281,11 @@ class initPackages {
       if (featured) {
         this.domEl.resultsCountContainer.el.innerHTML = `${this.domEl.featuredContainer.el?.children.length} Featured`;
       } else if (this._filters.q.length > 0) {
-        this.domEl.resultsCountContainer.el.innerHTML = `${
+        this.domEl.resultsCountContainer.el.textContent = `${
           this.packages.length
         } of ${
           this.allPackages.length
-        } search results for <span style='font-weight: 500;'>'${this._filters.q.join(
-          ","
-        )}'</span>`;
+        } search results for ${this._filters.q.join(",")}`;
       } else {
         this.domEl.resultsCountContainer.el.innerHTML = `${this.packages.length} of ${this.allPackages.length}`;
       }

--- a/webapp/packages/store_packages.py
+++ b/webapp/packages/store_packages.py
@@ -2,6 +2,7 @@ import talisker
 from webapp.decorators import login_required
 from flask import (
     Blueprint,
+    jsonify,
     request,
     session,
     make_response,
@@ -60,7 +61,7 @@ def package(package_type):
     )
     page_type = request.path[1:-1]
 
-    response = make_response(
+    response = jsonify(
         {
             "published_packages": [
                 package

--- a/webapp/search/views.py
+++ b/webapp/search/views.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, request, current_app as app, render_template
+from flask import Blueprint, jsonify, request, current_app as app, render_template
 
 from webapp.config import SEARCH_FIELDS
 from webapp.search.logic import (
@@ -62,9 +62,7 @@ def all_docs():
 
     docs = search_docs(search_term)[:limit]
 
-    return {
-        "docs": docs,
-    }
+    return jsonify({"docs": docs})
 
 
 @search.route("/all-topics")

--- a/webapp/search/views.py
+++ b/webapp/search/views.py
@@ -1,4 +1,10 @@
-from flask import Blueprint, jsonify, request, current_app as app, render_template
+from flask import (
+    Blueprint,
+    jsonify,
+    request,
+    current_app as app,
+    render_template,
+)
 
 from webapp.config import SEARCH_FIELDS
 from webapp.search.logic import (

--- a/webapp/search/views.py
+++ b/webapp/search/views.py
@@ -83,4 +83,6 @@ def all_topics():
     start = (page - 1) * limit
     end = start + limit
 
-    return {"topics": all_topics[start:end], "total_pages": total_pages}
+    return jsonify(
+        {"topics": all_topics[start:end], "total_pages": total_pages}
+    )

--- a/webapp/search/views.py
+++ b/webapp/search/views.py
@@ -40,7 +40,7 @@ def all_search_json():
         "docs": search_docs(term)[:limit],
         "topics": search_topics(term, 1, False)[:limit],
     }
-    return result
+    return jsonify(result)
 
 
 @search.route("/all-charms")

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -64,7 +64,7 @@ def get_publisher_details(publisher):
     }
 
     # HTML template will be returned here for the front end
-    return (context, status_code)
+    return jsonify(context), status_code
 
 
 @store.route("/packages.json")

--- a/webapp/topics/views.py
+++ b/webapp/topics/views.py
@@ -6,7 +6,7 @@ from canonicalwebteam.discourse.exceptions import (
     PathNotFoundError,
     RedirectFoundError,
 )
-from flask import Blueprint, abort, render_template, request, redirect
+from flask import Blueprint, abort, jsonify, render_template, request, redirect
 from webapp.helpers import discourse_api
 from jinja2 import Template
 from bs4 import BeautifulSoup
@@ -122,11 +122,13 @@ def topics_json():
     else:
         results = topic_list
 
-    return {
-        "topics": results,
-        "q": query,
-        "size": len(results),
-    }
+    return jsonify(
+        {
+            "topics": results,
+            "q": query,
+            "size": len(results),
+        }
+    )
 
 
 @topics.route("/topics")


### PR DESCRIPTION
## Done
Fixes [XSS alerts](https://github.com/canonical/charmhub.io/security/code-scanning):
- [32](https://github.com/canonical/charmhub.io/security/code-scanning/32)
  - make sure https://charmhub-io-2084.demos.haus/all-search `Docs` section returns results as in production
- [19](https://github.com/canonical/charmhub.io/security/code-scanning/19)
  - check https://charmhub-io-2084.demos.haus/publisher/<publisher_name> returns json (e.g. [Landscape](https://charmhub-io-2084.demos.haus/publisher/landscape))
- [18](https://github.com/canonical/charmhub.io/security/code-scanning/18)
  - check https://charmhub-io-2084.demos.haus/all-topics returns json
- [16](https://github.com/canonical/charmhub.io/security/code-scanning/16)
  - check https://charmhub-io-2084.demos.haus/all-search.json?q="query" returns json result (change query)
- [15](https://github.com/canonical/charmhub.io/security/code-scanning/15)
  - check https://charmhub-io-2084.demos.haus/topics.json returns json
- [14](https://github.com/canonical/charmhub.io/security/code-scanning/14)
  - https://charmhub-io-2084.demos.haus/charms and https://charmhub-io-2084.demos.haus/bundles renders the same as on production
- [9](https://github.com/canonical/charmhub.io/security/code-scanning/9)
  - this section seems to no longer be rendered anywhere on the website but I just replaced `innerHTML` with `textContent`

** Main fix is to return `json` as this will escape special characters **

## How to QA
See above.

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): no change in behaviour


