### PR TITLE
fix url substring sanitisation

### DIFF
--- a/webapp/topics/views.py
+++ b/webapp/topics/views.py
@@ -10,11 +10,13 @@ from flask import Blueprint, abort, render_template, request, redirect
 from webapp.helpers import discourse_api
 from jinja2 import Template
 from bs4 import BeautifulSoup
+from urllib.parse import urlparse
 
 from webapp.config import CATEGORIES
 
 DISCOURSE_API_KEY = getenv("DISCOURSE_API_KEY")
 DISCOURSE_API_USERNAME = getenv("DISCOURSE_API_USERNAME")
+ALLOWED_HOST = "charmhub.io"
 
 topics = Blueprint(
     "topics", __name__, template_folder="/templates", static_folder="/static"
@@ -59,8 +61,9 @@ class TopicParser(DocParser):
 
                     if navlink_href:
                         navlink_href = navlink_href.get("href")
+                        parsed_url = urlparse(navlink_href)
 
-                        if not navlink_href.startswith("https://charmhub.io"):
+                        if parsed_url.netloc != ALLOWED_HOST:
                             self.warnings.append("Invalid tutorial URL")
                             continue
 


### PR DESCRIPTION
## Done
- Makes sure URL matches its domain rather than just `startsWith`
  - Ensures no bypassing is allowed with subdomains

## How to QA
- Go to https://charmhub-io-2086.demos.haus/topics/kubeflow#an-ecosystem-for-mlops and make sure links for packages are as expected

## Testing
- [ ] This PR has tests
- [X] No testing required (explain why): no change in behaviour

