### PR TITLE
Clean up Vanilla overrides from charmhub.io

### DIFF
--- a/static/sass/_pattern_p-button-group.scss
+++ b/static/sass/_pattern_p-button-group.scss
@@ -49,7 +49,6 @@
       flex: 1;
       height: 100%;
       line-height: 1.5;
-      margin: 0 !important; // Required to override Vanilla button:not(:last-of-type):not(:only-of-type)
       padding: calc(0.4rem - 1px) 1rem;
       text-align: center;
       white-space: nowrap;

--- a/static/sass/_pattern_p-icon.scss
+++ b/static/sass/_pattern_p-icon.scss
@@ -38,19 +38,6 @@
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' height='12px' width='12px' version='1.1' viewBox='0 0 12 12'%3E%3Ctitle%3Erevisions copy 5%3C/title%3E%3Cg id='New-Cards-+-Topics' fill-rule='evenodd' fill='none'%3E%3Cg id='Store---With-topics' fill-rule='nonzero' fill='%23666' transform='translate(-614 -992)'%3E%3Cg id='revisions-copy-5' transform='translate(614 992)'%3E%3Cpath id='Shape' d='m1.3569 2.1573l0.8731 0.9695c-0.5929 0.7883-0.9443 1.7686-0.9443 2.8309 0 2.6037 2.1107 4.7143 4.7143 4.7143 2.3846 0 4.356-1.7705 4.67-4.0687l1.296 0.0006c-0.323 3.0099-2.8706 5.3541-5.966 5.3541-3.3137 0-6-2.6865-6-6.0003 0-1.4422 0.50887-2.7656 1.3569-3.8004zm2.7127 1.0049l1.9038 2.1526 3.4552 0.0001v1.2857h-4.0334l-2.2885-2.5864 0.9629-0.852zm6.8694-0.6118c0.422 0.6104 0.734 1.3028 0.906 2.0485l-1.33-0.0003c-0.115-0.3827-0.277-0.7449-0.48-1.0798l0.904-0.9684zm-3.65-2.4539c0.8271 0.18107 1.5904 0.53276 2.2511 1.0164l-0.8855 0.9484c-0.413-0.2819-0.8732-0.4998-1.3661-0.6396l0.0005-1.3252zm-2.0048-0.096547v1.2974c-0.5497 0.0838-1.0683 0.2625-1.5384 0.5189l-0.8793-0.97629c0.7196-0.44158 1.5396-0.73562 2.4177-0.84001z'/%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
   }
 
-  // XXX Ovi - 12.05.20: This can be removed once the new icon set is implemented in vanilla
-  .p-icon--filter {
-    @extend %icon;
-
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'%3E%3Cg fill='none' fill-rule='evenodd' stroke='%2306C' stroke-width='1.5' transform='translate(2 2.5)'%3E%3Cline x2='12' y1='.5' y2='.5'/%3E%3Cline x1='4' x2='8' y1='10.5' y2='10.5'/%3E%3Cline x1='2' x2='10' y1='5.5' y2='5.5'/%3E%3C/g%3E%3C/svg%3E");
-  }
-
-  // XXX Ovi - 12.05.20: This can be removed once the new icon set is implemented in vanilla
-  .p-icon--sort {
-    @extend %icon;
-
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' height='16px' width='16px' version='1.1' viewBox='0 0 16 16'%3E%3C!-- Generator: Sketch 64 (93537) - https://sketch.com --%3E%3Ctitle%3Esort-both%3C/title%3E%3Cdesc%3ECreated with Sketch.%3C/desc%3E%3Cg id='sort-both' fill='%2306C'%3E%3Cpolygon id='Triangle' points='8 2 11.333 7 4.6667 7'/%3E%3Cpolygon id='Triangle' points='8 9 11.333 14 4.6667 14' transform='translate(8 11.5) rotate(180) translate(-8 -11.5)'/%3E%3C/g%3E%3C/svg%3E");
-  }
 
   .p-icon--delete:hover {
     @include vf-icon-delete($color-negative);

--- a/static/sass/_pattern_p-list.scss
+++ b/static/sass/_pattern_p-list.scss
@@ -34,21 +34,6 @@
     }
   }
 
-  // Overide the default vanilla padding for p-list--divided
-  .p-list--divided.has-padding {
-    .p-list__item {
-      padding-block: $spv--small $spv--small;
-    }
-  }
-
-  .p-list--divided.has-separator-centered {
-    .p-list__item {
-      &:not(:first-of-type) {
-        margin-block-start: $spv--medium;
-      }
-    }
-  }
-
   .p-inline-list--stretch.p-list--reversed {
     > .p-inline-list__item:last-child {
       align-items: center;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -9,64 +9,9 @@ $breakpoint-navigation-threshold: 1220px; // keep it in sync with juju.is and br
 
 // Import Vanilla framework
 @import "vanilla-framework";
+@include vanilla;
 
-// Base Vanilla styles
-@include vf-base;
-
-// Vanilla components
-@include vf-p-accordion;
-@include vf-p-buttons;
-@include vf-p-card;
-@include vf-p-chip;
-@include vf-p-code-snippet;
-@include vf-p-forms;
-@include vf-p-form-help-text;
-@include vf-p-form-tick-elements;
-@include vf-p-form-validation;
-@include vf-p-grid;
-@include vf-p-headings;
-@include vf-p-heading-icon;
-@include vf-p-icons;
-@include vf-p-icon-fullscreen;
-@include vf-p-image;
-@include vf-p-status-label;
-@include vf-p-links;
-@include vf-p-lists;
-@include vf-p-media-object;
-@include vf-p-modal;
-@include vf-p-muted-heading;
-@include vf-p-notification;
-@include vf-p-navigation;
-@include vf-p-pagination;
-@include vf-p-search-and-filter;
-@include vf-p-search-box;
-@include vf-p-strip;
-@include vf-p-side-navigation;
-@include vf-p-side-navigation-expandable;
-@include vf-p-table-of-contents;
-@include vf-p-table-mobile-card;
-@include vf-p-tabs;
-@include vf-p-tooltips;
-@include vf-p-contextual-menu;
-@include vf-l-fluid-breakout;
-@include vf-p-icon-change-version;
-@include vf-p-icon-submit-bug;
-
-// Vanilla utilities
-@include vf-u-align;
-@include vf-u-animations;
-@include vf-u-clearfix;
-@include vf-u-floats;
-@include vf-u-layout;
-@include vf-u-off-screen;
-@include vf-u-hide;
-@include vf-u-margin-collapse;
-@include vf-u-padding-collapse;
-@include vf-u-vertically-center;
-@include vf-u-vertical-spacing;
-@include vf-u-text-muted;
-@include vf-u-no-max-width;
-@include vf-u-truncate;
+// Custom styles
 @import "pattern_p-card";
 @include p-charmhub-card;
 @import "pattern_grid";
@@ -136,8 +81,6 @@ $breakpoint-navigation-threshold: 1220px; // keep it in sync with juju.is and br
 @include l-charmhub-fluid-breakout;
 @import "charmhub_p-detail-inline-list";
 @include p-detail-inline-list;
-@include vf-l-application;
-@include vf-p-icon-status-waiting;
 @import "pattern_p-filter-panel";
 @include p-charmhub-filter-panel;
 @import "charmhub_releases";

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -156,22 +156,6 @@ body {
   min-height: 100vh;
 }
 
-// Ovi 13.07.2020 - This can be removed once a new version of global-nav is released
-// as the issue was fixed
-// https://github.com/canonical-web-and-design/global-nav/commit/03173d82a1f1d4b77f8e20e41ef552b90dbab798
-
-@media (width <= 875px) {
-  body {
-    padding-bottom: 0 !important;
-  }
-}
-
-// Ovi 16.07.2020 - This can be removed once this issue is closed
-// https://github.com/canonical-web-and-design/vanilla-framework/issues/3172
-.has-no-arrow-mobile.p-tabs::after {
-  content: "";
-}
-
 .package-card-icons {
   > * {
     display: inline-block;
@@ -295,14 +279,6 @@ h3 {
 
   @media screen and (max-width: $breakpoint-large - 1) {
     content: none;
-  }
-}
-
-// XXX Ovi 28.04.2021 - This can be removed once this issue is closed
-// https://github.com/canonical-web-and-design/vanilla-framework/issues/3723
-.l-fluid-breakout__item {
-  @media (min-width: $breakpoint-small) {
-    max-width: 30rem;
   }
 }
 
@@ -457,15 +433,6 @@ h3 {
 .modal-header-icon {
   height: 1rem !important;
   width: 1rem !important;
-}
-
-// XXX - Related to https://github.com/canonical/vanilla-framework/issues/4887
-.p-search-box .p-search-box__button .p-icon--search {
-  background-image: url("data:image/svg+xml,%3Csvg width=%2716%27 height=%2716%27 xmlns=%27http://www.w3.org/2000/svg%27%3E%3Cpath d=%27M6.964 1a5.964 5.964 0 014.709 9.623l4.303 4.305-1.06 1.06-4.306-4.305A5.964 5.964 0 116.963 1zm0 1.5a4.464 4.464 0 100 8.927 4.464 4.464 0 000-8.927z%27 fill=%27%23666%27 fill-rule=%27nonzero%27/%3E%3C/svg%3E") !important;
-}
-
-.p-search-box .p-search-box__reset .p-icon--close {
-  background-image: url("data:image/svg+xml,%3Csvg width=%2716%27 height=%2716%27 xmlns=%27http://www.w3.org/2000/svg%27%3E%3Cpath fill=%27%23666%27 fill-rule=%27nonzero%27 d=%27M13.041 1.898l1.06 1.06L9.062 8l5.04 5.042-1.06 1.06L8 9.062 2.96 14.1l-1.06-1.06L6.938 8 1.9 2.96l1.06-1.06 5.04 5.04z%27/%3E%3C/svg%3E") !important;
 }
 
 .p-search-box .p-search-box__input:placeholder-shown ~ .p-search-box__reset {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -147,15 +147,6 @@ $breakpoint-navigation-threshold: 1220px; // keep it in sync with juju.is and br
   margin-bottom: 1rem;
 }
 
-// XXX Ovi - 04.04.20: This can be removed once this issue is closed.
-// https://github.com/canonical-web-and-design/vanilla-framework/issues/1452
-body {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  grid-template-rows: auto auto auto 1fr auto;
-  min-height: 100vh;
-}
-
 .package-card-icons {
   > * {
     display: inline-block;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -453,15 +453,6 @@ h3 {
   columns: 3;
 }
 
-// Vanilla top aligns table cells which causes misalignment when a button is
-// present. This table is targeted to avoid potential issues with other
-// existing tables.
-// stylelint-disable
-.registered-charms-table td {
-  vertical-align: middle;
-}
-// stylelint-enable
-
 // Large icon for modal headers
 .modal-header-icon {
   height: 1rem !important;

--- a/templates/base_layout.html
+++ b/templates/base_layout.html
@@ -59,7 +59,7 @@
     <link rel="search" type="application/opensearchdescription+xml" title="Charmhub" href="/static/opensearch.xml" />
   </head>
 
-  <body>
+  <body class="l-site">
     <!-- Google Tag Manager (noscript) -->
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NNT2XX6"
     height="0" width="0" style="display: none; visibility: hidden;"></iframe></noscript>
@@ -106,7 +106,7 @@
         "url": "https://charmhub.io{{ self.meta_path() }}"
       }
     </script>
-    
+
     {% block structure_data_markup %}{% endblock %}
   </body>
 </html>

--- a/templates/details/actions.html
+++ b/templates/details/actions.html
@@ -25,7 +25,7 @@
             Learn about actions&nbsp;&gt;
           </a>
         </p>
-        <ul class="p-list--divided has-separator-centered">
+        <ul class="p-list--divided">
           {% for action, action_data in package.store_front.actions.items() %}
             <li class="p-list__item" style="margin-bottom: 1rem;" id="{{ action }}">
               <p class="p-heading--4">{{ action }}</p>

--- a/templates/details/configure-bundle.html
+++ b/templates/details/configure-bundle.html
@@ -27,7 +27,7 @@
         Learn about configurations&nbsp;&gt;
       </a>
     </p>
-      <ul class="p-list--divided has-separator-centered">
+      <ul class="p-list--divided">
         {% for key, value in subpackage.store_front.config.options.items() %}
         <li class="p-list__item" id="{{ key }}">
           <p class="p-heading--4">{{ key }} <span class="u-text--muted">&VerticalLine; {{ value.type }}</span></p>

--- a/templates/details/configure-charm.html
+++ b/templates/details/configure-charm.html
@@ -24,7 +24,7 @@
         Learn about configurations&nbsp;&gt;
       </a>
     </p>
-    <ul class="p-list--divided has-separator-centered">
+    <ul class="p-list--divided">
       {% for key, value in package.store_front.config.options.items() %}
       <li class="p-list__item" id="{{ key }}">
         <p class="p-heading--4">{{ key }} <span class="u-text--muted">&VerticalLine; {{ value.type }}</span></p>

--- a/templates/partial/_footer.html
+++ b/templates/partial/_footer.html
@@ -1,6 +1,6 @@
 <hr />
 
-<footer class="p-strip">
+<footer class="l-footer--sticky p-strip">
   <div class="row">
     <div class="col-3">
       <h2 class="p-heading--5">Juju</h2>

--- a/templates/publisher/list.html
+++ b/templates/publisher/list.html
@@ -188,7 +188,7 @@
                   {% endif %}
                 </td>
                 <td class="u-align--right">
-                  <button class="p-button--base u-no-margin--bottom" data-js="unregister-button" data-package-name="{{ registered_charm['name'] }}">Unregister</button>
+                  <button class="p-button--base is-dense u-no-margin--bottom" data-js="unregister-button" data-package-name="{{ registered_charm['name'] }}">Unregister</button>
                 </td>
               </tr>
               {% endfor %}
@@ -313,14 +313,14 @@
 
       const packageName = unregisterButton.dataset.packageName;
       currentPackage = packageName;
-      
+
       packageNameHolders.forEach((packageNameHolder) => {
         packageNameHolder.innerText = packageName;
       });
 
       unregisterConfirmationModal.classList.remove("u-hide");
     });
-  });  
+  });
 
   if (unregisterConfirmationModal) {
     unregisterConfirmationModal.addEventListener("click", (e) => {
@@ -332,12 +332,12 @@
     unregisterPackageButton.addEventListener("click", async () => {
       const formData = new FormData();
       formData.set("csrf_token", "{{ csrf_token() }}");
-        
+
       const response = await fetch(`/packages/${currentPackage}`, {
         method: "DELETE",
         body: formData,
       });
-      
+
       if (response.status === 200) {
         window.location.reload();
       } else {


### PR DESCRIPTION
## Done

- include whole of Vanilla styles
- remove unnecessary table overrides
- remove unnecessary list overrides
- remove unnecessary button margin overrides
- remove unnecessary icons
- use Vanilla sticky footer instead of custom one
- 
## How to QA

- Open demo https://charmhub-io-2087.demos.haus, click on search in top nav, type something, make sure search and X icons looks fine
- Check any Charm configuration page, make sure list with the content looks fine https://charmhub-io-2087.demos.haus/kafka/configurations
- Go to topics, check if layout looks fine https://charmhub-io-2087.demos.haus/topics
- Go to your charms, if you have registered names, make sure their table looks fine https://charmhub-io-2087.demos.haus/charms
- Keep an eye or any other possible regressions

## Testing
- [ ] This PR has tests
- [ ] No testing required (explain why): visual changes only

## Issue / Card
Fixes WD-18870

