### PR TITLE
add safe redirects for docs versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "babel-loader": "9.2.1",
     "css-loader": "7.1.2",
     "date-fns": "4.1.0",
+    "dompurify": "^3.2.4",
     "expose-loader": "5.0.0",
     "identity-obj-proxy": "3.0.0",
     "mermaid": "11.4.1",

--- a/static/js/src/base/redirect-docs-url.ts
+++ b/static/js/src/base/redirect-docs-url.ts
@@ -1,0 +1,26 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const selectElement = document.getElementById(
+    "version-select"
+  ) as HTMLSelectElement | null;
+
+  if (!selectElement) return;
+
+  selectElement.addEventListener("change", () => {
+    const url = selectElement.value.trim();
+
+    if (!url) return;
+
+    try {
+      const parsedUrl = new URL(url, window.location.origin);
+
+      // Allow only URLs starting with "http", "https", or "/"
+      if (/^(https?:\/\/|\/)/.test(parsedUrl.href)) {
+        window.location.href = parsedUrl.href;
+      } else {
+        console.error("Blocked unsafe redirect:", parsedUrl.href);
+      }
+    } catch (error) {
+      console.error("Failed to parse URL:", url, error);
+    }
+  });
+});

--- a/templates/details/_side-nav.html
+++ b/templates/details/_side-nav.html
@@ -5,7 +5,7 @@
   {% if _context.has_rendered_content %}<hr class="p-separator--shallow">{% endif %}{% set _context.has_rendered_content = true %}
   {% if versions | length > 1 %}
     <label for="version-select" class="u-hide">Version</label>
-    <select name="version-select" id="version-select" onChange="window.location.href=this.value">
+    <select name="version-select" id="version-select">
       {% for version in versions %}
         {% set active = docs_version == version['path'] %}
         <option value="{{ version_paths[version['path']] }}"{% if active %} selected{% endif %}>Version {{ version['version'] }}</option>
@@ -163,3 +163,4 @@
 {% endif %}
 
 <script src="{{ versioned_static('js/dist/docs-side-nav.js') }}"></script>
+<script src="{{ versioned_static('js/dist/redirect-docs-url.js') }}"></script>

--- a/templates/topics/document.html
+++ b/templates/topics/document.html
@@ -43,12 +43,12 @@
     <aside class="col-3">
       {% if versions | length > 1 %}
       <label for="version-select" class="u-hide">Version</label>
-      <select name="version-select" id="version-select" onChange="window.location.href=this.value">
-      {% for version in versions %}
-        {% set active = docs_version == version['path'] %}
-        <option value="{{ version_paths[version['path']] }}"{% if active %} selected{% endif %}>Version {{ version['version'] }}</option>
-      {% endfor %}
-      <select>
+      <select name="version-select" id="version-select">
+        {% for version in versions %}
+          {% set active = docs_version == version['path'] %}
+          <option value="{{ version_paths[version['path']] }}"{% if active %} selected{% endif %}>Version {{ version['version'] }}</option>
+        {% endfor %}
+      </select>
       {% endif %}
 
       <nav data-js="navigation" class="p-side-navigation" id="{{ navigation['path'] or 'default' }}">
@@ -103,4 +103,5 @@
 </section>
 
 <script src="{{ versioned_static('js/dist/docs-side-nav.js') }}"></script>
+<script src="{{ versioned_static('js/dist/redirect-docs-url.js') }}"></script>
 {% endblock %}

--- a/webpack.config.entry.js
+++ b/webpack.config.entry.js
@@ -2,6 +2,7 @@ module.exports = {
   docs: "./static/js/src/public/docs/index.js",
   "global-nav": "./static/js/src/base/global-nav.ts",
   "docs-side-nav": "./static/js/src/base/docs-side-nav.ts",
+  "redirect-docs-url": "./static/js/src/base/redirect-docs-url.ts",
   base: "./static/js/src/base/base.js",
   details: "./static/js/src/public/details/index.ts",
   details_overview: "./static/js/src/public/details/overview/index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3895,7 +3895,7 @@ domexception@^4.0.0:
   dependencies:
     webidl-conversions "^7.0.0"
 
-dompurify@^3.2.1:
+dompurify@^3.2.1, dompurify@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.2.4.tgz#af5a5a11407524431456cf18836c55d13441cd8e"
   integrity sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==


### PR DESCRIPTION
## Done
Adds safe redirects to avoid XSS.

## How to QA
Unfortunately, none of our docs have versions so the easiest way to QA is:
- Check out this branch
- Add the following dummy component to the `document.html` and `_side-nav.html` files:
```
<div id="test-urlencode">
  <h3>Redirect Test</h3>
  <label for="version-select">Test safe redirects:</label>
  <select id="version-select">
  <option value="">-- Select Test URL --</option>
  <option value="{{ '/docs/test?name=John Doe&role=admin' }}">Encoded Test 1</option>
  <option value="{{ '/docs/special characters & symbols' }}">Encoded Test 2</option>
  <option value="{{ 'javascript:alert(\'XSS\')' }}">Should Not Execute</option>
</select>
</div>
```
- Run the local host
- Then go to a topic (http://localhost:8045/topics/charmed-tempo-ha) and also a docs page (http://localhost:8045/kafka-k8s) and test the dropdowns
  - The first two links will return 404 but check the urls are correctly formatted
  - The final link should not redirect and there should be a warning in the console

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): no change in current behaviour

## Issue / Card
Fixes https://github.com/canonical/charmhub.io/security/code-scanning/8 and https://github.com/canonical/charmhub.io/security/code-scanning/7