### PR TITLE
encode packageName link

### DIFF
--- a/static/js/src/publisher-admin/pages/Publicise/PubliciseButtons.tsx
+++ b/static/js/src/publisher-admin/pages/Publicise/PubliciseButtons.tsx
@@ -44,7 +44,7 @@ function PubliciseButtons() {
       <Row>
         <Col size={7} className="col-start-large-3">
           <p>
-            <a href={`/${packageName}`}>
+            <a href={`/${encodeURIComponent(packageName || "")}`}>
               <img
                 alt=""
                 src={`/static/images/badges/${selectedLanguage}/charmhub-black.svg`}
@@ -85,7 +85,7 @@ function PubliciseButtons() {
       <Row>
         <Col size={7} className="col-start-large-3">
           <p>
-            <a href={`/${packageName}`}>
+            <a href={`/${encodeURIComponent(packageName || "")}`}>
               <img
                 alt=""
                 src={`/static/images/badges/${selectedLanguage}/charmhub-white.svg`}


### PR DESCRIPTION
## Done
- Encode `packageName` to prevent XSS.

## How to QA
- Go to a publisher charm and check the `Publicise` tab
- Ensure that the links on the dark and light buttons are working as expected

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): no change in behaviour

## Fixes
Fiex https://github.com/canonical/charmhub.io/security/code-scanning/6 and https://github.com/canonical/charmhub.io/security/code-scanning/5