### PR TITLE
encode bundle icon link

### DIFF
--- a/static/js/src/public/store-details/packages.ts
+++ b/static/js/src/public/store-details/packages.ts
@@ -776,7 +776,7 @@ function loadBundleIcons() {
       });
       bundleIcon.innerHTML = "";
       bundleIcon.style.backgroundImage = "none";
-      icon.src = `/${name}/icon-no-default`;
+      icon.src = `/${encodeURIComponent(name)}/icon-no-default`;
 
       bundleIcon.appendChild(icon);
     });


### PR DESCRIPTION
## Done
Encodes bundle icon link to prevent XSS.

## How to QA
- Go to a bundle (e.g. `/osm`)
- Check all bundle icons render as expected and that the links are as expected

## Testing
- [ ] This PR has tests
- [X] No testing required (explain why): no change in behaviour

## Issue / Card
Fixes https://github.com/canonical/charmhub.io/security/code-scanning/4
