### PR TITLE
safely append mermaid svg and code snippet

### DIFF
--- a/static/js/src/public/docs/mermaid.js
+++ b/static/js/src/public/docs/mermaid.js
@@ -29,19 +29,29 @@ async function renderSVG(block, index) {
   const content = block.innerText;
   const { svg } = await mermaid.render(`diagram-${index}`, content);
 
-  codeSnippet.innerHTML = `<div class="p-code-snippet__header">
-  <h5 class="p-code-snippet__title">Mermaid Diagram</h5>
+  codeSnippet.innerHTML = `
+    <div class="p-code-snippet__header">
+      <h5 class="p-code-snippet__title">Mermaid Diagram</h5>
+      <div class="p-code-snippet__dropdowns">
+        <select class="p-code-snippet__dropdown">
+          <option value="rendered">Rendered</option>
+          <option value="markup">Markup</option>
+        </select>
+      </div>
+    </div>
+  `;
 
-  <div class="p-code-snippet__dropdowns">
-    <select class="p-code-snippet__dropdown">
-      <option value="rendered">Rendered</option>
-      <option value="markup">Markup</option>
-    </select>
-  </div>
-</div>
+  const renderedDiv = document.createElement("div");
+  renderedDiv.className = "rendered";
+  renderedDiv.style.marginTop = "1rem";
+  renderedDiv.innerHTML = svg;
 
-<div class="rendered" style="margin-top: 1rem">${svg}</div>
-<div class="markup">${block.parentNode.outerHTML}</div>`;
+  const markupDiv = document.createElement("div");
+  markupDiv.className = "markup";
+  markupDiv.textContent = block.parentNode.outerHTML;
+
+  codeSnippet.appendChild(renderedDiv);
+  codeSnippet.appendChild(markupDiv);
 
   block.parentNode.parentNode.replaceChild(codeSnippet, block.parentNode);
 
@@ -81,7 +91,9 @@ async function initMermaid() {
   // Only if we have some blocks should we do anything
   if (mermaidBlocks) {
     mermaid.initialize({ startOnLoad: false, securityLevel: "antiscript" });
-    Promise.all(mermaidBlocks.map((block, index) => renderSVG(block, index)));
+    await Promise.all(
+      mermaidBlocks.map((block, index) => renderSVG(block, index))
+    );
   }
 }
 


### PR DESCRIPTION
## Done
Safely appends mermaid code snippet and svg to the dom to prevent XSS.

## How to QA
- I couldn't find any charm docs that render a mermaid diagram so the easiest way to QA is to check out this branch and add this test component to the bottom of the `mermaid.js` file:
```
// TEST COMPONENT TO CALL renderSVG
document.addEventListener("DOMContentLoaded", async () => {
  // Create fake Mermaid block
  const testBlock = document.createElement("div");
  testBlock.innerHTML = `<code>flowchart TD; A-->B</code>`;

  // Wrap in a parent div (to mimic actual DOM structure)
  const wrapper = document.createElement("div");
  wrapper.appendChild(testBlock);
  document.body.appendChild(wrapper);

  // Ensure the block is in the DOM before rendering
  await new Promise((resolve) => setTimeout(resolve, 100));

  // Call `renderSVG` to make sure the mermaid diagram renders in the UI
  await renderSVG(testBlock.firstChild, 0);
});
```
- Run localhost
- Go to a charm's docs page (e.g. localhost:8045/jenkins-agent/docs/reference-configurations)
- Check that the mermaid svg renders at the bottom
- Choose `markup` in the dropdown and ensure the code snippet renders

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): no change in behaviour

## Issue / Card
Fixes https://github.com/canonical/charmhub.io/security/code-scanning/3