### PR TITLE
safely render svg

### DIFF
--- a/static/js/src/public/docs/mermaid.js
+++ b/static/js/src/public/docs/mermaid.js
@@ -1,4 +1,5 @@
 import mermaid from "mermaid";
+import DOMPurify from "dompurify";
 
 // We don't get the "mermaid" code block id through
 // so be really hacky about it
@@ -44,7 +45,12 @@ async function renderSVG(block, index) {
   const renderedDiv = document.createElement("div");
   renderedDiv.className = "rendered";
   renderedDiv.style.marginTop = "1rem";
-  renderedDiv.innerHTML = svg;
+
+  const sanitizedSVG = DOMPurify.sanitize(svg, {
+    ADD_TAGS: ["svg", "g", "path", "rect", "circle", "text", "foreignObject"],
+    ADD_ATTR: ["viewBox", "xmlns", "width", "height", "style", "class", "id"],
+  });
+  renderedDiv.innerHTML = sanitizedSVG;
 
   const markupDiv = document.createElement("div");
   markupDiv.className = "markup";


### PR DESCRIPTION
## Done
Safely renders SVG by sanitising it to prevent XSS.

## How to QA
- I couldn't find any charm docs that render a mermaid diagram so the easiest way to QA is to check out this branch and add this test component to the bottom of the `mermaid.js` file:
```
// TEST COMPONENT TO CALL renderSVG
document.addEventListener("DOMContentLoaded", async () => {
  // Create fake Mermaid block
  const testBlock = document.createElement("div");
  testBlock.innerHTML = `<code>flowchart TD; A-->B</code>`;

  // Wrap in a parent div (to mimic actual DOM structure)
  const wrapper = document.createElement("div");
  wrapper.appendChild(testBlock);
  document.body.appendChild(wrapper);

  // Ensure the block is in the DOM before rendering
  await new Promise((resolve) => setTimeout(resolve, 100));

  // Call `renderSVG` to make sure the mermaid diagram renders in the UI
  await renderSVG(testBlock.firstChild, 0);
});
```
- Run localhost
- Go to a charm's docs page (e.g. localhost:8045/jenkins-agent/docs/reference-configurations)
- Check that the mermaid svg renders at the bottom
- Choose `markup` in the dropdown and ensure the code snippet renders

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): no change in behaviour

## Issue / Card
Fixes https://github.com/canonical/charmhub.io/security/code-scanning/3