### PR TITLE
fix code-scanning/25

### DIFF
--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -281,7 +281,7 @@ def details_docs(entity_name, path=None):
 
     # If no docs, redirect to main page
     if not package["store_front"]["docs_topic"]:
-        return redirect(f"/{entity_name}")
+        return redirect(url_for(".details_overview", entity_name=entity_name))
 
     docs_url_prefix = f"/{package['name']}/docs"
 

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -380,12 +380,14 @@ def details_configuration(entity_name, path=None):
 
         if not path and bundle_charms:
             default_charm = bundle_charms[0]
-            redirect_url = (
-                f"/{entity_name}/configurations/{default_charm['name']}"
+            return redirect(
+                url_for(
+                    ".details_configuration",
+                    entity_name=entity_name,
+                    path=default_charm["name"],
+                    channel=channel_request,
+                )
             )
-            if channel_request:
-                redirect_url = redirect_url + f"?channel={channel_request}"
-            return redirect(redirect_url)
 
         if path:
             if not any(d["name"] == path for d in bundle_charms):


### PR DESCRIPTION
## Done
Fixes the below redirects by adding `url_for` to ensure they are internal redirects.

## How to QA
- [25](https://github.com/canonical/charmhub.io/security/code-scanning/25)
  - go to https://charmhub-io-2097.demos.haus/lxd/docs (or any charm with no docs)
  - make sure it redirects to the charm description page
- [26](https://github.com/canonical/charmhub.io/security/code-scanning/26)
  - go to a bundle (i.e. /cos-lite)
  - make sure https://charmhub-io-2097.demos.haus/cos-lite/configurations redirects to the first configuration name

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): no change in behaviour

## Issue / Card
Fixes https://github.com/canonical/charmhub.io/security/code-scanning/25 and https://github.com/canonical/charmhub.io/security/code-scanning/26