### PR TITLE
add secure flag to cookies

### DIFF
--- a/tests/test_param_redirect.py
+++ b/tests/test_param_redirect.py
@@ -10,8 +10,12 @@ class MockCookies:
     def __init__(self, cookie={}):
         self.cookie = cookie
 
-    def set_cookie(self, name, data, expires):
-        self.cookie[name] = {"data": data, "expires": expires}
+    def set_cookie(self, name, data, expires, secure=False):
+        self.cookie[name] = {
+            "data": data,
+            "expires": expires,
+            "secure": secure,
+        }
 
     def get(self, name):
         return self.cookie[name]

--- a/webapp/helpers.py
+++ b/webapp/helpers.py
@@ -149,7 +149,9 @@ def param_redirect_exec(req, make_response, redirect):
             response = make_response(
                 redirect(f'{redirect_data["endpoint"]}?{"&".join(params)}')
             )
-            response.set_cookie("param_redirect", "", expires=0, secure=True, httponly=True)
+            response.set_cookie(
+                "param_redirect", "", expires=0, secure=True, httponly=True
+            )
             return response
     return None
 

--- a/webapp/helpers.py
+++ b/webapp/helpers.py
@@ -125,6 +125,7 @@ def param_redirect_capture(req, resp):
                 ),
                 # Set expiration for 10 days in the future
                 expires=datetime.now() + timedelta(days=10),
+                secure=True,
             )
 
     return resp
@@ -148,7 +149,7 @@ def param_redirect_exec(req, make_response, redirect):
             response = make_response(
                 redirect(f'{redirect_data["endpoint"]}?{"&".join(params)}')
             )
-            response.set_cookie("param_redirect", "", expires=0)
+            response.set_cookie("param_redirect", "", expires=0, secure=True, httponly=True)
             return response
     return None
 


### PR DESCRIPTION
## Done
- Adds `secure` flag to cookies

## How to QA
- Check out this branch and run the localhost

- For `param_redirect_capture`:
  - In a terminal, run `curl -i "http://localhost:8045/accept-invite?package=test&token=123"`
  - In the `Set-Cookie: param_redirect` header, make sure the `Secure` flag is there

- For `param_redirect_exec`
  - Go to `webapp/publisher/views.py` and comment out line 124 (@login_required)
  - In a terminal, run:
    ```curl -i --cookie "param_redirect={\"endpoint\": \"/accept-invite\", \"params\": {\"package\": \"test\", \"token\": \"123\"}}" "http://localhost:8045/accept-invite"```
    - You should see something like:
      `Set-Cookie: param_redirect=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; Path=/`
    - Run `curl -i "http://localhost:8045/accept-invite"`
    - Check the headers, there should be no `param_redirect` cookie

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): updated tests

## Issue / Card
Fixes https://github.com/canonical/charmhub.io/security/code-scanning/11 and https://github.com/canonical/charmhub.io/security/code-scanning/10
