### PR TITLE
safely redirect after registering a name

### DIFF
--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -406,7 +406,10 @@ def post_register_name():
                     )
                 )
 
-    return redirect(f"/{data['type']}s")
+    if data["type"] == "charm":
+        return redirect("/charms")
+    elif data["type"] == "bundle":
+        return redirect("/bundles")
 
 
 @publisher.route("/register-name-dispute")


### PR DESCRIPTION
## Done
Checks whether type is a charm or bundle to validate no malicious redirects

## How to QA
- Go to `/register-name`
- Register a test charm name
- Ensure page redirects to `/charms`
- Go back to `/register-name`
- Register a test bundle name
- Ensure page redirects to `/bundles`

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): no change in behaviour

## Issue / Card
Fixes https://github.com/canonical/charmhub.io/security/code-scanning/23
