### PR TITLE
safely redirect draft interface

### DIFF
--- a/webapp/integrations/views.py
+++ b/webapp/integrations/views.py
@@ -7,6 +7,7 @@ from flask import (
     make_response,
     redirect,
     abort,
+    url_for,
 )
 from flask.json import jsonify
 from github import Github
@@ -80,7 +81,7 @@ def single_interface(path):
         and "status" in interface
         and interface["status"] == "draft"
     ):
-        return redirect(f"/integrations/{path}/draft")
+        return redirect(url_for(".single_interface", path=f"{path}/draft"))
 
     context = {"interface": interface}
     return render_template("interfaces/index.html", **context)


### PR DESCRIPTION
## Done
- Adds safe redirect for an interface that only has a draft

## How to QA
- Go to `/integrations/auth_proxy`
- Make sure it redirects to `/integrations/auth_proxy/draft`

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): no change in behaviour

## Issue / Card
Fixes https://github.com/canonical/charmhub.io/security/code-scanning/22