### PR TITLE
add httponly flag for secure cookie

### DIFF
--- a/tests/test_param_redirect.py
+++ b/tests/test_param_redirect.py
@@ -10,11 +10,12 @@ class MockCookies:
     def __init__(self, cookie={}):
         self.cookie = cookie
 
-    def set_cookie(self, name, data, expires, secure=False):
+    def set_cookie(self, name, data, expires, secure=False, httponly=True):
         self.cookie[name] = {
             "data": data,
             "expires": expires,
             "secure": secure,
+            "httponly": httponly,
         }
 
     def get(self, name):

--- a/webapp/helpers.py
+++ b/webapp/helpers.py
@@ -126,6 +126,7 @@ def param_redirect_capture(req, resp):
                 # Set expiration for 10 days in the future
                 expires=datetime.now() + timedelta(days=10),
                 secure=True,
+                httponly=True,
             )
 
     return resp


### PR DESCRIPTION
## Done
Adds `httponly` flag when setting cookie to prevent javascript being used for XSS

## How to QA
- Check out this branch and run the localhost
- In a terminal, run `curl -i "http://localhost:8045/accept-invite?package=test&token=123"`
- In the `Set-Cookie: param_redirect` header, make sure the `HttpOnly` flag is there

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): no change in behaviour

## Issue / Card
Fixes https://github.com/canonical/charmhub.io/security/code-scanning/10