### PR TITLE
add C4container and C4component to mermaid types

### DIFF
--- a/static/js/src/public/docs/mermaid.js
+++ b/static/js/src/public/docs/mermaid.js
@@ -15,6 +15,8 @@ const START_SYNTAX = [
   "requirementDiagram",
   "gitGraph",
   "C4Context",
+  "C4Container",
+  "C4Component",
   "mindmap",
   "timeline",
   "pie",


### PR DESCRIPTION
## Done
Adds `C4Component` and `C4Container` to list of accepted mermaid syntax types.

## How to QA
- Check out this branch
- Run `dotrun`
- Create a mermaid diagram in a file (e.g. `static/js/src/public/details/index.ts`) 
  - I have copied and pasted the whole file here for ease as you need to import `initMermaid` as well - https://pastebin.canonical.com/p/vnG2s9fhpX/
- Go to a charm (e.g. http://localhost:8045/github-runner) and check that the mermaid diagram renders at the bottom
- Change the `C4Container` in the file to `C4Component`
- Reload the page and make sure the diagram still renders as expected

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why):

## Issue / Card
Fixes https://chat.canonical.com/canonical/pl/kxnymwwpetfpxyajr1xn5jsqao