### PR TITLE
fix create track stuck in pending

### DIFF
--- a/static/js/src/publisher-admin/pages/Releases/Releases.tsx
+++ b/static/js/src/publisher-admin/pages/Releases/Releases.tsx
@@ -32,6 +32,7 @@ export default function Releases() {
   const { packageName } = useParams();
   const { data: releaseData } = useReleases(packageName);
   const { data: packageData } = usePackage(packageName);
+  const { refetch } = usePackage(packageName);
 
   const [selectedTrack, setSelectedTrack] = useState<string>("");
   const [selectedArch, setSelectedArch] = useState<string>("");
@@ -206,6 +207,7 @@ export default function Releases() {
             onClose={() => setShowSidePanel(false)}
             setSelectedTrack={setSelectedTrack}
             onSuccess={() => {
+              refetch();
               setShowSuccessMessage(true);
             }}
           />

--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -464,7 +464,7 @@ def post_create_track(charm_name):
         auto_phasing_percentage = float(auto_phasing_percentage)
 
     response = publisher_gateway.create_track(
-        session["account-auth"],
+        session,
         charm_name,
         track_name,
         version_pattern,


### PR DESCRIPTION
## Done
- Changes how session is passed to the `store-api` to fix 500 error and "Add track" getting stuck in a pending state.

## How to QA
- Go to a charm that you own that has track guardrails (if you don't have this, just let me know and I can add you to my charm)
- Try to add a new track (guardrails for mine are for the pattern 1.1, 2.1, 3.1 etc)
- Make sure the track is added

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): no change in behaviour

## Issue / Card
Fixes [WD-20522](https://warthogs.atlassian.net/browse/WD-20522)



[WD-20522]: https://warthogs.atlassian.net/browse/WD-20522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ