### PR TITLE
fix: disable talisker for charmed deployment

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,8 +2,12 @@
 # The flask application must be defined in this file under the variable name `app`.
 # See - https://documentation.ubuntu.com/rockcraft/en/latest/reference/extensions/flask-framework/
 import os
+import logging
 
 # canonicalwebteam.flask-base requires SECRET_KEY to be set, this must be done before importing the app
 os.environ["SECRET_KEY"] = os.environ["FLASK_SECRET_KEY"]
+
+# disable talisker logger, as it is not used in this application and clutters logs
+logging.getLogger("talisker.context").disabled = True
 
 from webapp.app import app


### PR DESCRIPTION
## Done
- disable talisker logging in charmed deployment (it is cluttering the logs with warnings about it being disabled)

## How to QA
- Trust :)
- As a hack: run locally with `dotrun exec` followed by `FLASK_SECRET_KEY=test flask run`
- See that the `track API called when there is no active context, data will not be stored` line is not showing

