### PR TITLE
feat: add tracing integration

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   deploy-staging:
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/deployment-action' }}
+    if: ${{ ( github.ref == 'refs/heads/main' && github.event.workflow_run.conclusion == 'success') || github.event_name == 'workflow_dispatch' }}
     uses: ./.github/workflows/juju_deploy.yaml
     with:
         environment: "Staging"
@@ -20,7 +20,7 @@ jobs:
         VAULT_APPROLE_SECRET_ID: ${{ secrets.VAULT_APPROLE_SECRET_ID }}
 
   deploy-prod:
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/deployment-action' }}
+    if: ${{ ( github.ref == 'refs/heads/main' && github.event.workflow_run.conclusion == 'success') || github.event_name == 'workflow_dispatch' }}
     uses: ./.github/workflows/juju_deploy.yaml
     with:
         environment: "Production"

--- a/app.py
+++ b/app.py
@@ -3,6 +3,9 @@
 # See - https://documentation.ubuntu.com/rockcraft/en/latest/reference/extensions/flask-framework/
 import os
 import logging
+from opentelemetry.instrumentation.requests import RequestsInstrumentor
+from opentelemetry.instrumentation.flask import FlaskInstrumentor
+from opentelemetry.trace import Span
 
 # canonicalwebteam.flask-base requires SECRET_KEY to be set, this must be done before importing the app
 os.environ["SECRET_KEY"] = os.environ["FLASK_SECRET_KEY"]
@@ -11,3 +14,20 @@ os.environ["SECRET_KEY"] = os.environ["FLASK_SECRET_KEY"]
 logging.getLogger("talisker.context").disabled = True
 
 from webapp.app import app
+
+UNTRACED_ROUTES = [
+    "/_status",
+    ".*[.jpg|.jpeg|.png|.gif|.ico|.css|.js|.json]$",
+]
+
+
+def request_hook(span: Span, environ):
+    if span and span.is_recording():
+        span.update_name(f"{environ['REQUEST_METHOD']} {environ['PATH_INFO']}")
+
+
+# Add tracing auto instrumentation
+FlaskInstrumentor().instrument_app(
+    app, excluded_urls=",".join(UNTRACED_ROUTES), request_hook=request_hook
+)
+RequestsInstrumentor().instrument()

--- a/charm/charmcraft.yaml
+++ b/charm/charmcraft.yaml
@@ -16,3 +16,9 @@ description: The charm for the charmhub.io website, built with the PaaS app char
 
 extensions:
   - flask-framework
+
+requires:
+  tracing:
+    interface: tracing
+    optional: true
+    limit: 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,13 @@ black==24.10.0
 flake8==7.1.1
 Flask-Caching==2.3.0
 responses==0.25.3
+
+# Observability
+opentelemetry-api==1.32.1
+opentelemetry-exporter-otlp==1.32.1
+opentelemetry-exporter-otlp-proto-http==1.32.1
+opentelemetry-instrumentation==0.53b1
+opentelemetry-instrumentation-wsgi==0.53b1
+opentelemetry-instrumentation-flask==0.53b1
+opentelemetry-instrumentation-requests==0.53b1
+opentelemetry-sdk==1.32.1

--- a/webapp/observability/utils.py
+++ b/webapp/observability/utils.py
@@ -1,0 +1,19 @@
+import functools
+from opentelemetry import trace
+
+tracer = trace.get_tracer(__name__)
+
+
+def trace_function(fn):
+    """Decorator to trace function calls."""
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        with tracer.start_as_current_span(fn.__name__):
+            return fn(*args, **kwargs)
+
+    return wrapper
+
+
+def start_span(span_name):
+    return tracer.start_as_current_span(span_name)

--- a/webapp/packages/logic.py
+++ b/webapp/packages/logic.py
@@ -8,6 +8,7 @@ from typing import List, Dict, TypedDict, Any, Union
 
 from canonicalwebteam.store_api.publishergw import PublisherGW
 from canonicalwebteam.exceptions import StoreApiError
+from webapp.observability.utils import trace_function
 from webapp.store.logic import format_slug
 
 publisher_gateway = PublisherGW("charm", talisker.requests.get_session())
@@ -345,6 +346,7 @@ def get_store_categories() -> List[Dict[str, str]]:
     return categories
 
 
+@trace_function
 def get_package(
     package_name: str,
     fields: List[str],


### PR DESCRIPTION
## Done
- Add tracing interface to charm
- send traces to collector, add flask instrumentation
## How to QA
- This is deployed on staging.charmhub.io
- go to staging cos [explore page](http://cos-staging.webdesign.canonical.com/stg-webdesign-cos-lite-grafana/explore) (need VPN)
- select tempo as data source, select "Search" for query type
- select charmhub-io under service name
- see traces
- go to https://staging.charmhub.io/sysconfig/card.json
- see trace with nested spans
## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): charm integrations


