### PR TITLE
render markdown correctly in charms with no docs

### DIFF
--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -17,7 +17,7 @@ from webapp.decorators import (
     redirect_uppercase_to_lowercase,
     store_maintenance,
 )
-from webapp.helpers import discourse_api
+from webapp.helpers import discourse_api, markdown_to_html
 from webapp.store import logic
 from webapp.config import SEARCH_FIELDS
 
@@ -254,6 +254,7 @@ def details_overview(entity_name):
     else:
         navigation = None
         description, summary = logic.add_description_and_summary(package)
+        description = markdown_to_html(description)
 
     context["description"] = description
     context["summary"] = summary


### PR DESCRIPTION
## Done
- Make sure markdown renders properly when a charm has no docs

## How to QA
- Go to /testflinger-agent-host and make sure `` sections render as code
- Check a charm with docs (e.g. /grafana-k8s) and make sure description is rendered the same as before

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): no change in behaviour

## Issue / Card
Fixes [WD-21663](https://warthogs.atlassian.net/browse/WD-21663)

