### PR TITLE
fix: make configuration description optional

### DIFF
--- a/templates/details/configure-charm.html
+++ b/templates/details/configure-charm.html
@@ -31,7 +31,9 @@
         {% if value.default %}
         <p style="overflow-wrap: break-word; white-space: pre-wrap;"><span class="u-text--muted">Default:</span> {{ value.default }}</p>
         {% endif %}
+        {% if value.description %}
         <p style="overflow-wrap: break-word; white-space: pre-wrap;">{{ value.description | markdown | safe }}</p>
+        {% endif %}
       </li>
       {% endfor %}
     </ul>


### PR DESCRIPTION
## Done
- Make description for configurations optional
## How to QA
- go to `/mysql-connect-integrator/configurations`
- see actual configurations instead of a 500
## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): bug fix