### PR TITLE
check status before showing empty state

### DIFF
--- a/static/js/src/public/details/integrations/components/App/App.tsx
+++ b/static/js/src/public/details/integrations/components/App/App.tsx
@@ -52,7 +52,7 @@ export const App = () => {
   const availableFilters = useRecoilValue(filterChipsSelector);
   const [fragment, setFragment] = useState(window.location.hash || "");
 
-  const { data } = useQuery(
+  const { data, status } = useQuery(
     ["integrations", charm],
     () => getIntegrations(charm),
     {
@@ -245,19 +245,7 @@ export const App = () => {
           </Col>
         </Row>
       )}
-      {!data && (
-        <div
-          style={{
-            display: "flex",
-            justifyContent: "center",
-            alignItems: "center",
-            minHeight: "10rem",
-          }}
-        >
-          <Spinner text="Loading..." />
-        </div>
-      )}
-      {integrationCount === 0 && (
+      {status === "success" && integrationCount === 0 && (
         <div className="p-strip u-no-padding--top">
           <div className="u-fixed-width u-equal-height">
             <div className="charm-empty-docs-icon u-vertically-center">

--- a/static/js/src/public/details/integrations/components/App/__tests__/App.test.tsx
+++ b/static/js/src/public/details/integrations/components/App/__tests__/App.test.tsx
@@ -168,11 +168,15 @@ describe("getIntegrations function", () => {
 });
 
 describe("Empty App component", () => {
-  jest.mock("../App", () => ({
-    getIntegrations: jest.fn().mockResolvedValue([]),
-  }));
-
   const queryClient = new QueryClient();
+
+  beforeEach(() => {
+    global.fetch = jest.fn().mockImplementation(() =>
+      Promise.resolve({
+        json: () => Promise.resolve({ grouped_relations: undefined }),
+      })
+    );
+  });
 
   test("should display message when no integrations are found", async () => {
     render(
@@ -184,10 +188,9 @@ describe("Empty App component", () => {
     );
 
     await waitFor(() => {
-      const message = screen.getByText(
-        /No Integrations have been added for this charm/i
-      );
-      expect(message).toBeInTheDocument();
+      expect(
+        screen.getByText(/No Integrations have been added for this charm/i)
+      ).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Done
- Checks the status of integrations before showing empty state
- Removes double loading spinner

## How to QA
- Go to a charm with integrations (i.e. https://charmhub-io-2129.demos.haus/mongodb/integrations)
  - Make sure the "No Integrations" notification doesn't display while loading
  - Make sure there is only one `Loading` spinner
- Go to a charm with no integrations (i.e. https://charmhub-io-2129.demos.haus/metacontroller/integrations)
  - Make sure the "No Integrations" notification displays

## Testing
- [x] This PR has tests: fixed existing test
- [ ] No testing required (explain why):

## Issue / Card
Fixes [WD-21996](https://warthogs.atlassian.net/browse/WD-21996)


[WD-21996]: https://warthogs.atlassian.net/browse/WD-21996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ