### PR TITLE
feat: add tracing to store_api calls

### DIFF
--- a/tests/publisher/test_publisher_views.py
+++ b/tests/publisher/test_publisher_views.py
@@ -45,10 +45,7 @@ class TestPublisherViews(unittest.TestCase):
         self.assertIn(b"test-email", res.data)
         self.assertIn(b"test-username", res.data)
 
-    @patch(
-        "canonicalwebteam.store_api.publishergw."
-        "PublisherGW.get_package_metadata"
-    )
+    @patch("webapp.store_api.publisher_gateway.get_package_metadata")
     def test_get_publisher(self, mock_get_package_metadata):
         mock_get_package_metadata.return_value = sample_charm
         for endpoint in [
@@ -61,10 +58,7 @@ class TestPublisherViews(unittest.TestCase):
             res = self.client.get(f"/test-entity/{endpoint}")
             self.assertEqual(res.status_code, 200)
 
-    @patch(
-        "canonicalwebteam.store_api.publishergw."
-        "PublisherGW.get_package_metadata"
-    )
+    @patch("webapp.store_api.publisher_gateway.get_package_metadata")
     def test_get_package(self, mock_get_package_metadata):
         mock_get_package_metadata.return_value = {"name": "test-package"}
         res = self.client.get("/api/packages/test-entity")
@@ -74,10 +68,7 @@ class TestPublisherViews(unittest.TestCase):
             {"success": True, "data": mock_get_package_metadata.return_value},
         )
 
-    @patch(
-        "canonicalwebteam.store_api.publishergw."
-        "PublisherGW.update_package_metadata"
-    )
+    @patch("webapp.store_api.publisher_gateway.update_package_metadata")
     def test_update_package(self, mock_update_package_metadata):
         mock_update_package_metadata.return_value = {"name": "test-package"}
         res = self.client.patch(
@@ -85,10 +76,7 @@ class TestPublisherViews(unittest.TestCase):
         )
         self.assertEqual(res.status_code, 200)
 
-    @patch(
-        "canonicalwebteam.store_api.publishergw."
-        "PublisherGW.update_package_metadata"
-    )
+    @patch("webapp.store_api.publisher_gateway.update_package_metadata")
     def test_update_package_failure(self, mock_update_package_metadata):
         mock_update_package_metadata.side_effect = StoreApiResponseErrorList(
             "test-error", 500, []
@@ -99,10 +87,7 @@ class TestPublisherViews(unittest.TestCase):
         self.assertEqual(res.status_code, 500)
         self.assertEqual(res.json["success"], False)
 
-    @patch(
-        "canonicalwebteam.store_api.publishergw."
-        "PublisherGW.update_package_metadata"
-    )
+    @patch("webapp.store_api.publisher_gateway.update_package_metadata")
     def test_update_package_unauthorized(self, mock_update_package_metadata):
         mock_update_package_metadata.side_effect = StoreApiResponseErrorList(
             "test-error", 500, [{"message": "unauthorized"}]
@@ -114,10 +99,7 @@ class TestPublisherViews(unittest.TestCase):
         self.assertEqual(res.json["success"], False)
         self.assertEqual(res.json["message"], "Package not found")
 
-    @patch(
-        "canonicalwebteam.store_api.publishergw."
-        "PublisherGW.get_account_packages"
-    )
+    @patch("webapp.store_api.publisher_gateway.get_account_packages")
     def test_list_page(self, mock_get_account_packages):
         mock_get_account_packages.return_value = [
             {
@@ -152,7 +134,7 @@ class TestPublisherViews(unittest.TestCase):
         self.assertIn(b"Success", res.data)
         self.assertEqual(res.status_code, 200)
 
-    @patch("canonicalwebteam.store_api.publishergw.PublisherGW.accept_invite")
+    @patch("webapp.store_api.publisher_gateway.accept_invite")
     def test_accept_post_invite(self, mock_accept_invite):
         mock_accept_invite.return_value.status_code = 204
         res = self.client.post(
@@ -161,7 +143,7 @@ class TestPublisherViews(unittest.TestCase):
         )
         self.assertEqual(res.status_code, 200)
 
-    @patch("canonicalwebteam.store_api.publishergw.PublisherGW.accept_invite")
+    @patch("webapp.store_api.publisher_gateway.accept_invite")
     def test_accept_post_invite_failed(self, mock_accept_invite):
         mock_accept_invite.return_value.status_code = 401
         res = self.client.post(
@@ -171,7 +153,7 @@ class TestPublisherViews(unittest.TestCase):
         self.assertEqual(res.status_code, 500)
         self.assertEqual(res.json["message"], "An error occured")
 
-    @patch("canonicalwebteam.store_api.publishergw.PublisherGW.reject_invite")
+    @patch("webapp.store_api.publisher_gateway.reject_invite")
     def test_reject_post_invite(self, mock_reject_invite):
         mock_reject_invite.return_value.status_code = 204
         res = self.client.post(
@@ -180,19 +162,13 @@ class TestPublisherViews(unittest.TestCase):
         )
         self.assertEqual(res.status_code, 200)
 
-    @patch(
-        "canonicalwebteam.store_api.publishergw"
-        ".PublisherGW.get_collaborators"
-    )
+    @patch("webapp.store_api.publisher_gateway.get_collaborators")
     def test_get_collaborators(self, mock_get_collaborators):
         mock_get_collaborators.return_value = [{"name": "collaborator"}]
         res = self.client.get("/api/packages/test-entity/collaborators")
         self.assertEqual(res.status_code, 200)
 
-    @patch(
-        "canonicalwebteam.store_api.publishergw"
-        ".PublisherGW.get_collaborators"
-    )
+    @patch("webapp.store_api.publisher_gateway.get_collaborators")
     def test_get_collaborators_failed(self, mock_get_collaborators):
         mock_get_collaborators.side_effect = StoreApiResponseErrorList(
             "test-error", 500, []
@@ -200,10 +176,7 @@ class TestPublisherViews(unittest.TestCase):
         res = self.client.get("/api/packages/test-entity/collaborators")
         self.assertEqual(res.status_code, 500)
 
-    @patch(
-        "canonicalwebteam.store_api.publishergw"
-        ".PublisherGW.get_pending_invites"
-    )
+    @patch("webapp.store_api.publisher_gateway.get_pending_invites")
     def test_get_pending_invites(self, mock_get_pending_invites):
         mock_get_pending_invites.return_value = {
             "invites": [{"name": "invite"}]
@@ -211,10 +184,7 @@ class TestPublisherViews(unittest.TestCase):
         res = self.client.get("/api/packages/test-entity/invites")
         self.assertEqual(res.status_code, 200)
 
-    @patch(
-        "canonicalwebteam.store_api.publishergw"
-        ".PublisherGW.invite_collaborators"
-    )
+    @patch("webapp.store_api.publisher_gateway.invite_collaborators")
     def test_invite_collaborators(self, mock_invite_collaborators):
         mock_invite_collaborators.return_value = {"tokens": ["token"]}
         res = self.client.post(
@@ -223,7 +193,7 @@ class TestPublisherViews(unittest.TestCase):
         )
         self.assertEqual(res.status_code, 200)
 
-    @patch("canonicalwebteam.store_api.publishergw.PublisherGW.revoke_invites")
+    @patch("webapp.store_api.publisher_gateway.revoke_invites")
     def test_revoke_invite(self, mock_revoke_invites):
         mock_revoke_invites.return_value.status_code = 204
         res = self.client.delete(
@@ -237,10 +207,7 @@ class TestPublisherViews(unittest.TestCase):
         self.assertEqual(res.status_code, 200)
         self.assertIn(b"Register a new", res.data)
 
-    @patch(
-        "canonicalwebteam.store_api.publishergw"
-        ".PublisherGW.register_package_name"
-    )
+    @patch("webapp.store_api.publisher_gateway.register_package_name")
     def test_post_register_name(self, mock_register_package_name):
         mock_register_package_name.return_value = True
         res = self.client.post(
@@ -253,10 +220,7 @@ class TestPublisherViews(unittest.TestCase):
         )
         self.assertEqual(res.status_code, 302)
 
-    @patch(
-        "canonicalwebteam.store_api.publishergw"
-        ".PublisherGW.register_package_name"
-    )
+    @patch("webapp.store_api.publisher_gateway.register_package_name")
     def test_post_register_name_already_owned(
         self, mock_register_package_name
     ):
@@ -297,19 +261,13 @@ class TestPublisherViews(unittest.TestCase):
             res.data,
         )
 
-    @patch(
-        "canonicalwebteam.store_api.publishergw"
-        ".PublisherGW.unregister_package_name"
-    )
+    @patch("webapp.store_api.publisher_gateway.unregister_package_name")
     def test_delete_package(self, mock_unregister_package_name):
         mock_unregister_package_name.return_value.status_code = 200
         res = self.client.delete("/packages/test-package")
         self.assertEqual(res.status_code, 200)
 
-    @patch(
-        "canonicalwebteam.store_api.publishergw"
-        ".PublisherGW.unregister_package_name"
-    )
+    @patch("webapp.store_api.publisher_gateway.unregister_package_name")
     def test_delete_package_failed(self, mock_unregister_package_name):
         mock_unregister_package_name.return_value.status_code = 500
         mock_unregister_package_name.return_value.json = {
@@ -318,7 +276,7 @@ class TestPublisherViews(unittest.TestCase):
         res = self.client.delete("/packages/test-package")
         self.assertEqual(res.status_code, 500)
 
-    @patch("canonicalwebteam.store_api.publishergw.PublisherGW.create_track")
+    @patch("webapp.store_api.publisher_gateway.create_track")
     def test_post_create_track(self, mock_create_track):
         mock_create_track.return_value.status_code = 201
         mock_create_track.return_value.json = lambda: {"track": "test-track"}
@@ -332,7 +290,7 @@ class TestPublisherViews(unittest.TestCase):
         )
         self.assertEqual(res.status_code, 201)
 
-    @patch("canonicalwebteam.store_api.publishergw.PublisherGW.create_track")
+    @patch("webapp.store_api.publisher_gateway.create_track")
     def test_post_create_track_already_exists(self, mock_create_track):
         mock_create_track.return_value.status_code = 409
         mock_create_track.return_value.json = lambda: {"track": "test-track"}
@@ -346,7 +304,7 @@ class TestPublisherViews(unittest.TestCase):
         )
         self.assertEqual(res.status_code, 409)
 
-    @patch("canonicalwebteam.store_api.publishergw.PublisherGW.get_releases")
+    @patch("webapp.store_api.publisher_gateway.get_releases")
     @patch("webapp.publisher.logic.process_releases")
     @patch("webapp.publisher.logic.get_all_architectures")
     def test_get_releases(

--- a/webapp/integrations/views.py
+++ b/webapp/integrations/views.py
@@ -1,6 +1,4 @@
 from datetime import datetime
-from talisker import requests
-
 from flask import (
     Blueprint,
     render_template,
@@ -13,10 +11,9 @@ from flask.json import jsonify
 from github import Github
 from os import getenv
 
-from canonicalwebteam.store_api.publishergw import PublisherGW
-
 from webapp.integrations.logic import Interfaces
 from webapp.observability.utils import trace_function
+from webapp.store_api import publisher_gateway
 
 interface_logic = Interfaces()
 
@@ -100,7 +97,6 @@ def single_interface(path):
 def get_single_interface(interface_name, status):
     repo_has_interface = interface_logic.repo_has_interface(interface_name)
 
-    publisher_gateway = PublisherGW("charm", requests.get_session())
     other_requirers = publisher_gateway.find(requires=[interface_name]).get(
         "results", []
     )

--- a/webapp/login/views.py
+++ b/webapp/login/views.py
@@ -2,13 +2,13 @@ import os
 import talisker
 import flask
 
-from canonicalwebteam.store_api.publishergw import PublisherGW
 from flask_wtf.csrf import generate_csrf, validate_csrf
 
 from canonicalwebteam.candid import CandidClient
 from webapp.helpers import is_safe_url
 from webapp import authentication
 from webapp.observability.utils import trace_function
+from webapp.store_api import publisher_gateway
 
 login = flask.Blueprint(
     "login", __name__, template_folder="/templates", static_folder="/static"
@@ -22,7 +22,6 @@ LOGIN_LAUNCHPAD_TEAM = os.getenv(
 
 request_session = talisker.requests.get_session()
 candid = CandidClient(request_session)
-publisher_gateway = PublisherGW("charm", request_session)
 
 
 @trace_function

--- a/webapp/packages/logic.py
+++ b/webapp/packages/logic.py
@@ -2,16 +2,14 @@ import re
 
 import yaml
 
-import talisker
 from flask import make_response
 from typing import List, Dict, TypedDict, Any, Union
 
-from canonicalwebteam.store_api.publishergw import PublisherGW
 from canonicalwebteam.exceptions import StoreApiError
 from webapp.observability.utils import trace_function
 from webapp.store.logic import format_slug
+from webapp.store_api import publisher_gateway
 
-publisher_gateway = PublisherGW("charm", talisker.requests.get_session())
 
 Packages = TypedDict(
     "Packages",
@@ -310,7 +308,7 @@ def get_packages(
 
 @trace_function
 def parse_categories(
-    categories_json: Dict[str, List[Dict[str, str]]]
+    categories_json: Dict[str, List[Dict[str, str]]],
 ) -> List[Dict[str, str]]:
     """
     :param categories_json: The returned json from publishergw get_categories

--- a/webapp/packages/store_packages.py
+++ b/webapp/packages/store_packages.py
@@ -1,4 +1,3 @@
-import talisker
 from webapp.decorators import login_required
 from flask import (
     Blueprint,
@@ -14,8 +13,7 @@ from webapp.packages.logic import (
 )
 from webapp.config import SEARCH_FIELDS as FIELDS
 from webapp.observability.utils import trace_function
-
-from canonicalwebteam.store_api.publishergw import PublisherGW
+from webapp.store_api import publisher_gateway
 
 
 store_packages = Blueprint(
@@ -51,8 +49,6 @@ def package(package_type):
     :returns: Response: The HTTP response containing the JSON data of the
     packages.
     """
-
-    publisher_gateway = PublisherGW("charm", talisker.requests.get_session())
 
     publisher_packages = publisher_gateway.get_account_packages(
         session["account-auth"], "charm", include_collaborations=True

--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -1,5 +1,3 @@
-import talisker
-from canonicalwebteam.store_api.publishergw import PublisherGW
 from canonicalwebteam.exceptions import StoreApiResponseErrorList
 from flask import (
     Blueprint,
@@ -16,6 +14,7 @@ from webapp.config import DETAILS_VIEW_REGEX
 from webapp.decorators import login_required, cached_redirect
 from webapp.publisher.logic import get_all_architectures, process_releases
 from webapp.observability.utils import trace_function
+from webapp.store_api import publisher_gateway
 
 publisher = Blueprint(
     "publisher",
@@ -23,7 +22,6 @@ publisher = Blueprint(
     template_folder="/templates",
     static_folder="/static",
 )
-publisher_gateway = PublisherGW("charm", talisker.requests.get_session())
 
 
 @trace_function

--- a/webapp/search/logic.py
+++ b/webapp/search/logic.py
@@ -1,18 +1,16 @@
 from flask_caching import Cache
 
-from canonicalwebteam.store_api.publishergw import PublisherGW
 
-import talisker
 import requests
 from webapp.config import SEARCH_FIELDS
 from webapp.packages.logic import parse_package_for_card
 from webapp.observability.utils import trace_function
+from webapp.store_api import publisher_gateway
 
 DISCOURSE_URL = "https://discourse.charmhub.io"
 DOCS_URL = "https://canonical-juju.readthedocs-hosted.com/"
 
 cache = Cache(config={"CACHE_TYPE": "simple"})
-publisher_gateway = PublisherGW("charm", talisker.requests.get_session())
 
 
 @trace_function

--- a/webapp/search/views.py
+++ b/webapp/search/views.py
@@ -4,9 +4,6 @@ from flask import (
     request,
     render_template,
 )
-from talisker import requests
-from canonicalwebteam.store_api.publishergw import PublisherGW
-
 from webapp.config import SEARCH_FIELDS
 from webapp.search.logic import (
     search_docs,
@@ -15,13 +12,12 @@ from webapp.search.logic import (
     search_bundles,
 )
 from webapp.observability.utils import trace_function
+from webapp.store_api import publisher_gateway
 
 
 search = Blueprint(
     "search", __name__, template_folder="/templates", static_folder="/static"
 )
-
-publisher_gateway = PublisherGW("charm", requests.get_session())
 
 
 @trace_function

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -1,17 +1,15 @@
 import humanize
-from talisker import requests
 from canonicalwebteam.discourse import DocParser
 from canonicalwebteam.discourse.exceptions import PathNotFoundError
 from canonicalwebteam.flask_base.decorators import (
     exclude_xframe_options_header,
 )
 from canonicalwebteam.exceptions import StoreApiResponseErrorList
-from canonicalwebteam.store_api.publishergw import PublisherGW
-from canonicalwebteam.store_api.devicegw import DeviceGW
 from flask import Blueprint, Response, abort, url_for
 from flask import jsonify, redirect, render_template, request, make_response
 from pybadges import badge
 
+from webapp.store_api import publisher_gateway
 from webapp.config import DETAILS_VIEW_REGEX
 from webapp.decorators import (
     redirect_uppercase_to_lowercase,
@@ -21,16 +19,14 @@ from webapp.helpers import discourse_api, markdown_to_html
 from webapp.store import logic
 from webapp.config import SEARCH_FIELDS
 from webapp.observability.utils import trace_function
+from webapp.store_api import device_gateway
 
 
 store = Blueprint(
     "store", __name__, template_folder="/templates", static_folder="/static"
 )
-publisher_gateway = PublisherGW("charm", requests.get_session())
-device_gateway = DeviceGW("charm", requests.get_session())
 
 
-@trace_function
 @store.route("/publisher/<regex('[a-z0-9-]*[a-z][a-z0-9-]*'):publisher>")
 def get_publisher_details(publisher):
     """

--- a/webapp/store_api.py
+++ b/webapp/store_api.py
@@ -1,0 +1,28 @@
+import talisker
+from canonicalwebteam.store_api.devicegw import DeviceGW
+from canonicalwebteam.store_api.publishergw import PublisherGW
+from webapp.observability.utils import trace_function
+
+
+def decorate_all_methods(decorator, cls):
+    class WrappedClass(cls):
+        pass
+
+    for attr_name in dir(cls):
+        # ignore private and special methods like __init__ etc.
+        if attr_name.startswith("__"):
+            continue
+        attr = getattr(cls, attr_name)
+        # only decorate callable attributes (these are mostly API calls)
+        if callable(attr):
+            setattr(WrappedClass, attr_name, decorator(attr))
+
+    return WrappedClass
+
+
+TracedPubilsherGW = decorate_all_methods(trace_function, PublisherGW)
+TracedDeviceGW = decorate_all_methods(trace_function, DeviceGW)
+
+request_session = talisker.requests.get_session()
+publisher_gateway = TracedPubilsherGW("charm", request_session)
+device_gateway = TracedDeviceGW("charm", request_session)


### PR DESCRIPTION
## Done
- Make all store_api instances (traced) singletons.
- change exclude pattern to match any static files
## How to QA
- spin up o11y locally as per `observability/README.md`
- make a bunch of requests on charmhub (click around some charms, login)
- should see requests made to store_api
- you SHOULD NOT see any requests to static js, .css, images etc
## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): tracing

## Issue / Card
Fixes WD-21964
