### PR TITLE
fix: Update Ubuntu logo for charm details

### DIFF
--- a/static/js/src/publisher-admin/utils/__tests__/generateReleaseChannelRows.test.tsx
+++ b/static/js/src/publisher-admin/utils/__tests__/generateReleaseChannelRows.test.tsx
@@ -117,7 +117,7 @@ describe("generateReleaseChannelRows", () => {
     expect(screen.getByText("7")).toBeInTheDocument();
     expect(screen.getByAltText("Ubuntu")).toHaveAttribute(
       "src",
-      "https://assets.ubuntu.com/v1/adac6928-ubuntu.svg"
+      "https://assets.ubuntu.com/v1/b4ba06f2-Ubuntu%20logo.svg"
     );
     expect(screen.getByAltText("CentOS")).toHaveAttribute(
       "src",

--- a/static/js/src/publisher-admin/utils/generateReleaseChannelRows.tsx
+++ b/static/js/src/publisher-admin/utils/generateReleaseChannelRows.tsx
@@ -129,10 +129,10 @@ export function ResourcesCell({ resources }: { resources: Resource[] }) {
 const PLATFORM_ICONS: { [key: string]: JSX.Element } = {
   ubuntu: (
     <img
-      src="https://assets.ubuntu.com/v1/adac6928-ubuntu.svg"
+      src="https://assets.ubuntu.com/v1/b4ba06f2-Ubuntu%20logo.svg"
       alt="Ubuntu"
-      width="89"
-      height="20"
+      width="85"
+      height="30"
       className="p-image--base"
     />
   ),

--- a/templates/details/_details-header.html
+++ b/templates/details/_details-header.html
@@ -75,10 +75,10 @@
         {# Machine bundles and they have the "series" attribute: we mark them as Ubuntu platform #}
         <div class="series-base">
           <div class="series-base__title">
-            <img src="https://assets.ubuntu.com/v1/adac6928-ubuntu.svg"
+            <img src="https://assets.ubuntu.com/v1/b4ba06f2-Ubuntu%20logo.svg"
                  alt="Ubuntu"
-                 width="89"
-                 height="20"
+                 width="85"
+                 height="30"
                  class="p-image--base">
           </div>
         </div>
@@ -87,10 +87,10 @@
           <div class="series-base">
             <div class="series-base__title">
               {% if platform.startswith("ubuntu") %}
-                <img src="https://assets.ubuntu.com/v1/adac6928-ubuntu.svg"
+                <img src="https://assets.ubuntu.com/v1/b4ba06f2-Ubuntu%20logo.svg"
                      alt="Ubuntu"
-                     width="89"
-                     height="20"
+                     width="85"
+                     height="30"
                      class="p-image--base">
               {% elif platform.startswith("centos") %}
                 <img src="https://assets.ubuntu.com/v1/fd5cc5d8-CentOS.svg"


### PR DESCRIPTION
## Done

Updates Ubuntu logo in Platform listing.

## How to QA

Go to charm page for Ubuntu platrorm:
https://charmhub-io-2138.demos.haus/postgresql

Make sure Ubuntu logo is up to date.

Go to publisher's view of releases page or any charm on Ubuntu platform.
https://charmhub-io-2138.demos.haus/landscape-keystone/releases

Make sure Ubuntu logo in releases listing is up to date.



## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes WD-22489

## Screenshots

https://charmhub-io-2138.demos.haus/postgresql
<img width="1431" alt="image" src="https://github.com/user-attachments/assets/4dd17115-bd98-4ae2-b817-f01e2f95b039" />

https://charmhub-io-2138.demos.haus/landscape-keystone/releases
<img width="1442" alt="image" src="https://github.com/user-attachments/assets/480d36e3-aeff-4860-a2c0-172faa02a62e" />
