### PR TITLE
redirect postgresql docs to RTD

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -30,3 +30,7 @@ interfaces: integrations
 interfaces/(?P<interface>.*)/?: /integrations/{interface}
 interfaces/(?P<interface>.*).json: /integrations/{interface}.json
 interfaces/(?P<interface>.*)/(?P<status>.*).json: /integrations/{interface}/{status}.json
+
+# RTD redirects
+postgresql/docs/(?P<path>.*)/?: https://canonical-charmed-postgresql.readthedocs-hosted.com/{path}/
+postgresql-k8s/docs/(?P<path>.*)/?: https://canonical-charmed-postgresql-k8s.readthedocs-hosted.com/{path}/


### PR DESCRIPTION
## Done
- Adds wildcard redirects for PostgreSQL docs as they have now been moved to RTD
- Links should just redirect to the first trailing path due to redirects set up on RTD by the TA
  - E.g. `reference/troubleshooting/cli-helpers/` should redirect to https://canonical-charmed-postgresql.readthedocs-hosted.com/14/reference/

## How to QA
- Go to https://charmhub-io-2143.demos.haus/postgresql/docs/{query} (e.g. /how-to/deploy)
  - Make sure it redirects to the corresponding RTD page (in this case, it should just go to `/how-to`)
- Go to https://charmhub-io-2143.demos.haus/postgresql-k8s/docs/{query} (e.g. /tutorial)
  - Make sure it redirects to the corresponding RTD page

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): redirects

## Issue / Card
Fixes [WD-22588](https://warthogs.atlassian.net/browse/WD-22588)

[WD-22588]: https://warthogs.atlassian.net/browse/WD-22588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ