### PR TITLE
fix k8s redirects path

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -32,5 +32,5 @@ interfaces/(?P<interface>.*).json: /integrations/{interface}.json
 interfaces/(?P<interface>.*)/(?P<status>.*).json: /integrations/{interface}/{status}.json
 
 # RTD redirects
-postgresql/docs/(?P<path>.*)/?: https://canonical-charmed-postgresql.readthedocs-hosted.com/{path}/
-postgresql-k8s/docs/(?P<path>.*)/?: https://canonical-charmed-postgresql-k8s.readthedocs-hosted.com/{path}/
+postgresql/docs/(?P<path>.*)/?: https://canonical-charmed-postgresql.readthedocs-hosted.com/14/{path}/
+postgresql-k8s/docs/(?P<path>.*)/?: https://canonical-charmed-postgresql-k8s.readthedocs-hosted.com/14/{path}/


### PR DESCRIPTION
## Done
- Adds docs version to K8s docs redirects (should be redirected to v14)

## How to QA
- Go to postgresql/docs/{query}
  - Make sure it redirects to https://canonical-charmed-postgresql.readthedocs-hosted.com/14/{query}/
- Go to postgresql-k8s/docs/{query}
  - Make sure it redirects to https://canonical-charmed-postgresql-k8s.readthedocs-hosted.com/14/{query}/

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): fixing redirects

