### PR TITLE
WD-13679: Add overlay with custom data to charm info

### DIFF
--- a/templates/partial/_channel-map.html
+++ b/templates/partial/_channel-map.html
@@ -81,7 +81,17 @@
   <div class="p-charm-header__code">
     <div class="p-tooltip--information">
       <div>
-        <code>juju deploy {{ package["name"] }}{% if package["default-release"]["channel"]["name"] and package["default-release"]["channel"]["name"] != "stable" %} --channel {{ package["default-release"]["channel"]["name"] }}{% endif %}</code>
+        {% block juju_cmd %}
+          {% set channel_part = "" %}
+          {% set extra_flags_part = "" %}
+          {% if package["default-release"]["channel"]["name"] and package["default-release"]["channel"]["name"] != "stable" %}
+            {% set channel_cmd_part = "--channel " + package["default-release"]["channel"]["name"] %}
+          {% endif %}
+          {% if package["overlay_data"] and package["overlay_data"]["juju_cmd_extra_flags"] %}
+            {% set extra_flags_part = package["overlay_data"]["juju_cmd_extra_flags"] %}
+          {% endif %}
+          <code>juju deploy {{ package["name"] }} {{ channel_cmd_part }} {{ extra_flags_part }}</code>
+        {% endblock %}
       </div>
       <div class="instruction-tooltip">
         <div class="p-tooltip__button" role="button" aria-controls="icon-tooltip-modal" tabindex="0">

--- a/tests/store/test_store_logic.py
+++ b/tests/store/test_store_logic.py
@@ -9,6 +9,7 @@ from webapp.store.logic import (
     process_libraries,
     add_store_front_data,
     process_revision,
+    add_overlay_data,
 )
 from mock_data.mock_store_logic import (
     sample_channel_map,
@@ -186,3 +187,15 @@ class TestProcessRevision(TestCase):
         }
 
         self.assertEqual(process_revision(revision), processed_revision)
+
+
+class TestAddOverlayData(TestCase):
+    def test_add_overlay_data(self):
+        package = { "name": "postgresql-k8s", "other": "test data" }
+        result = add_overlay_data(package)
+        self.assertEqual({ "juju_cmd_extra_flags": "--trust" }, result["overlay_data"])
+
+    def test_overlay_data_not_needed(self):
+        package = { "name": "no-data", "other": "test data" }
+        result = add_overlay_data(package)
+        self.assertEqual(package, result)

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -1,5 +1,6 @@
 import sys
 import datetime
+import json
 from collections import OrderedDict
 import re
 import humanize
@@ -599,3 +600,20 @@ def format_slug(slug):
         .replace("And", "and")
         .replace("Iot", "IoT")
     )
+
+with open("webapp/store/overlay.json") as overlay_file:
+    overlay = json.load(overlay_file)
+
+@trace_function
+def add_overlay_data(package):
+    """
+    Adds custom hard-coded overlay.json data to the package object
+    :param package: The package object retrieved from the snapcraft API
+    :return: The package object with an additional "overlay" key containing extra info
+    """
+
+    if overlay.get(package["name"]) is not None:
+        package["overlay_data"] = overlay[package["name"]].copy()
+        print(package["overlay_data"])
+
+    return package

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -614,6 +614,5 @@ def add_overlay_data(package):
 
     if overlay.get(package["name"]) is not None:
         package["overlay_data"] = overlay[package["name"]].copy()
-        print(package["overlay_data"])
 
     return package

--- a/webapp/store/overlay.json
+++ b/webapp/store/overlay.json
@@ -1,0 +1,11 @@
+{
+  "postgresql-k8s": {
+    "juju_cmd_extra_flags": "--trust"
+  },
+  "pgbouncer-k8s": {
+    "juju_cmd_extra_flags": "--trust"
+  },
+  "mongodb-k8s": {
+    "juju_cmd_extra_flags": "--trust"
+  }
+}

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -144,6 +144,7 @@ def get_package(entity_name, channel_request=None, fields=FIELDS):
         package["channel-map"] = channel_map["channel-map"]
 
     package = logic.add_store_front_data(package, True)
+    package = logic.add_overlay_data(package)
 
     for channel in package["channel-map"]:
         channel["channel"]["released-at"] = logic.convert_date(


### PR DESCRIPTION
## Done

Add a custom overlay with data that can be customized in a JSON file to the charm info. The data from the overlay enriches the data that comes from Snapcraft API, adding information not provided by the endpoint but that it is requested by other stakeholders.

Use the overlay to mark which packages need the `--trust` flag in the `juju deploy` command displayed in the charm details.

## How to QA

I have identified 2 more packages needing the `--trust` flag in the command to deploy them (in addition to the 2 mentioned in the Jira ticket linked below). The following packages should have the flag:
  - [postgresql-k8s]()
  - [pgbouncer-k8s]()
  - [mongodb-k8s]()
  - [mysql-k8s]()

The rest of packages should still be displayed as before (no `--trust` flag or any other change).

## Testing
- [x] This PR has tests
- [  ] No testing required (explain why):

## Issue / Card

Fixes [WD-13679](https://warthogs.atlassian.net/browse/WD-13679)
