### PR TITLE
WD-13797 - Add trust flag to grafana-k8s

### DIFF
--- a/webapp/store/overlay.json
+++ b/webapp/store/overlay.json
@@ -10,5 +10,8 @@
   },
   "mysql-k8s": {
     "juju_cmd_extra_flags": "--trust"
+  },
+  "grafana-k8s": {
+    "juju_cmd_extra_flags": "--trust"
   }
 }


### PR DESCRIPTION
## Done

Add trust flag to grafana-k8s in the overlay.json file.

## How to QA

Go to Demos and check that the trust flag is added to grafana-k8s charm.

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): Just a modification to a JSON file.

## Issue / Card

Fixes #1664 
