### PR TITLE
fix: highlighting lib names ending with same suffix

### DIFF
--- a/templates/details/libraries/libraries_layout.html
+++ b/templates/details/libraries/libraries_layout.html
@@ -21,7 +21,7 @@
           <ul class="p-side-navigation__list">
             {% for lib in libraries %}
             <li class="p-side-navigation__item">
-                <a class="p-side-navigation__link" {% if request.path.endswith(lib['name']) or request.path.endswith(lib['name'] + '/source-code') %}aria-current="page"{% endif %} href="/{{ entity_name }}/libraries/{{ lib['name'] }}" style="color: #111;">{{ lib["name"] }}</a>
+                <a class="p-side-navigation__link" {% if request.path.endswith('libraries/' + lib['name']) or request.path.endswith('libraries/' + lib['name'] + '/source-code') %}aria-current="page"{% endif %} href="/{{ entity_name }}/libraries/{{ lib['name'] }}" style="color: #111;">{{ lib["name"] }}</a>
             </li>
             {% endfor %}
           </ul>


### PR DESCRIPTION
## Done
- fix duplicate active link when they have the same suffix
## How to QA
- go to https://charmhub-io-2158.demos.haus/tempo-coordinator-k8s/libraries/tracing
- only one lib highlighted
## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): bug fix

## Issue / Card
Fixes #2155 
