### PR TITLE
fix: Update invitation email placeholder

### DIFF
--- a/static/js/src/publisher-admin/pages/Collaboration/InviteCollaborator.tsx
+++ b/static/js/src/publisher-admin/pages/Collaboration/InviteCollaborator.tsx
@@ -96,7 +96,7 @@ function InviteCollaborator({ setShowSidePanel }: Props): JSX.Element {
           type="email"
           id="collaborator-email"
           label={<strong>1. Email</strong>}
-          placeholder="yourname@example.com"
+          placeholder="colleague@company.com"
           help="Collaborator email linked to the Ubuntu One account"
           value={activeInviteEmail}
           onInput={(


### PR DESCRIPTION
## Done
- Update invitation email placeholder from `yourname@example.com` to `colleague@company.com`
- A small thing but it confused me at first, I thought I needed to enter my email address until I fully read the form.

## How to QA
- Visit a charm
- Add a collaborator

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): Covered by previous tests

## Issue / Card
Fixes #

## Screenshots
