### PR TITLE
fix: add permissions to jobs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,7 +2,8 @@ name: Test coverage
 on:
   schedule:
     - cron: "0 22 * * 5"
-
+permissions:
+  contents: read
 jobs:
   test:
     name: test
@@ -49,55 +50,56 @@ jobs:
           retention-days: 1
   
   publish-coverage-report:
-      name: publish-coverage-report
-      runs-on: ubuntu-latest
-      needs: test
-      continue-on-error: true
-      steps:
-        - uses: actions/checkout@v4
-          with:
-            ref: gh-pages
-            token: ${{ secrets.GITHUB_TOKEN }}
-        - name: Cleanup coverage directory
-          run: |
-            rm -rf coverage
-            mkdir coverage
-        - name: Download coverage report artifact
-          uses: actions/download-artifact@v4
-          with:
-            name: charmhubio-coverage
-            path: coverage
-        # user git configs are needed for git commands to work
-        # actual authentication is done using secrets.GITHUB_TOKEN with write permission
-        - name: Set Git User
-          run: |
-            git config --global user.email "github-action@example.com"
-            git config --global user.name "GitHub Action"
-        - name: Push coverage Report
-          timeout-minutes: 3
-          run: |
-            git add .
-            git commit -m "workflow: update coverage report"
-            
-            # In case of another action job pushing to gh-pages while we are rebasing for the current job
-            while true; do
-              git pull --rebase
-              if [ $? -ne 0 ]; then
-                echo "Failed to rebase. Please review manually."
-                exit 1
-              fi
-  
-              git push
-              if [ $? -eq 0 ]; then
-                echo "Successfully pushed HTML report to repo."
-                exit 0
-              fi
-            done
-        - name: Output Report URL as Worfklow Annotation
-          run: |
-            FULL_HTML_REPORT_URL=https://canonical.github.io/charmhub.io/coverage
-            echo "::notice title=Published Playwright Test Report::$FULL_HTML_REPORT_URL"
+    name: publish-coverage-report
+    runs-on: ubuntu-latest
+    needs: test
+    continue-on-error: true
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Cleanup coverage directory
+        run: |
+          rm -rf coverage
+          mkdir coverage
+      - name: Download coverage report artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: charmhubio-coverage
+          path: coverage
+      # user git configs are needed for git commands to work
+      # actual authentication is done using secrets.GITHUB_TOKEN with write permission
+      - name: Set Git User
+        run: |
+          git config --global user.email "github-action@example.com"
+          git config --global user.name "GitHub Action"
+      - name: Push coverage Report
+        timeout-minutes: 3
+        run: |
+          git add .
+          git commit -m "workflow: update coverage report"
+          
+          # In case of another action job pushing to gh-pages while we are rebasing for the current job
+          while true; do
+            git pull --rebase
+            if [ $? -ne 0 ]; then
+              echo "Failed to rebase. Please review manually."
+              exit 1
+            fi
 
+            git push
+            if [ $? -eq 0 ]; then
+              echo "Successfully pushed HTML report to repo."
+              exit 0
+            fi
+          done
+      - name: Output Report URL as Worfklow Annotation
+        run: |
+          FULL_HTML_REPORT_URL=https://canonical.github.io/charmhub.io/coverage
+          echo "::notice title=Published Playwright Test Report::$FULL_HTML_REPORT_URL"
 
   tics-report:
     runs-on: [self-hosted, linux, amd64, tiobe, noble]

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -14,6 +14,8 @@ on:
         options:
           - Production
           - Staging
+permissions:
+  contents: read
 jobs:
   setup:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,6 +7,9 @@ on:
 env:
   SECRET_KEY: insecure_test_key
 
+permissions:
+  contents: read
+
 jobs:
   run-image:
     runs-on: ubuntu-latest
@@ -212,6 +215,9 @@ jobs:
 
   check-inclusive-naming:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Done
The GITHUB_TOKEN in the workflows have broad write permissions across many scopes (issues, pages, deployments, packages...). Adding permissions limits the token's power and improves CI/CD security.

## How to QA

- Go to https://github.com/canonical/charmhub.io/pull/2168/checks
- Click on the job in the workflow run.
- Expand the “Set up job” step.
- Check the “GITHUB_TOKEN Permissions” section.
- Verify that the required permissions are present:
   - If the job only reads repository content, contents: read is enough.
   - If it modifies or comments on a pull request, it needs pull-requests: write.

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-24340
