### PR TITLE
feature: added RTD redirects for mysql and mysql-k8s

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -34,3 +34,5 @@ interfaces/(?P<interface>.*)/(?P<status>.*).json: /integrations/{interface}/{sta
 # RTD redirects
 postgresql/docs/(?P<path>.*)/?: https://canonical-charmed-postgresql.readthedocs-hosted.com/14/{path}/
 postgresql-k8s/docs/(?P<path>.*)/?: https://canonical-charmed-postgresql-k8s.readthedocs-hosted.com/14/{path}/
+mysql/docs/(?P<path>.*)/?: https://canonical-charmed-mysql.readthedocs-hosted.com/{path}/
+mysql-k8s/docs/(?P<path>.*)/?: https://canonical-charmed-mysql-k8s.readthedocs-hosted.com/{path}/


### PR DESCRIPTION
## Done
added wildcard redirects for Charmed MySQL doc links

## How to QA
- try to visit https://.../mysql/docs/h-external-access
  - you should be redirected to https://canonical-charmed-mysql.readthedocs-hosted.com/h-external-access/ (but you will see a login screen instead)
- try to visit http://.../mysql-k8s/docs/h-external-access
  - you should be redirected to https://canonical-charmed-mysql-k8s.readthedocs-hosted.com/h-external-access/ (but you will see a login screen instead)


## Testing
- [ ] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes WD-24851

## Screenshots
