### PR TITLE
Wd 24523 add cache to packages logic and views

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ beautifulsoup4==4.12.3
 canonicalwebteam.candid==0.9.0
 canonicalwebteam.discourse==6.3.0
 canonicalwebteam.image-template==1.8.0
-canonicalwebteam.store-api==6.9.0
+canonicalwebteam.store-api==7.0.0
 canonicalwebteam.docstring-extractor==1.2.0
 
 Flask-WTF==1.2.2

--- a/webapp/packages/logic.py
+++ b/webapp/packages/logic.py
@@ -43,9 +43,12 @@ def get_icon(media):
 
 
 @trace_function
-def fetch_packages(fields: List[str], query_params: Dict[str, Any], libraries: bool = False) -> Packages:
+def fetch_packages(
+    fields: List[str], query_params: Dict[str, Any], libraries: bool = False
+) -> Packages:
     """
-    Fetches packages from the store API based on the specified fields and parse the packages.
+    Fetches packages from the store API based on the specified fields
+    and parse the packages.
 
     :param: fields (List[str]): A list of fields to include in the package
     data.
@@ -347,7 +350,8 @@ def get_store_categories() -> List[Dict[str, str]]:
 
         categories = list(
             filter(
-                lambda cat: cat["name"] != "featured", all_categories["categories"]
+                lambda cat: cat["name"] != "featured",
+                all_categories["categories"],
             )
         )
         redis_cache.set(key, categories, ttl=3600)

--- a/webapp/packages/logic.py
+++ b/webapp/packages/logic.py
@@ -307,27 +307,6 @@ def get_packages(
 
 
 @trace_function
-def parse_categories(
-    categories_json: Dict[str, List[Dict[str, str]]],
-) -> List[Dict[str, str]]:
-    """
-    :param categories_json: The returned json from publishergw get_categories
-    :returns: A list of categories in the format:
-    [{"name": "Category", "slug": "category"}]
-    """
-
-    categories = []
-
-    if "categories" in categories_json:
-        for category in categories_json["categories"]:
-            categories.append(
-                {"slug": category, "name": format_slug(category)}
-            )
-
-    return categories
-
-
-@trace_function
 def get_store_categories() -> List[Dict[str, str]]:
     """
     Fetches all store categories.


### PR DESCRIPTION
## Done
- Add cache to the following views:
    - /store.json
    - /{package-name}/card.json
    - get-categories

## How to QA
#### Demo
- Go to https://charmhub-io-2182.demos.haus/ and check that the page is the same compared to https://charmhub.io/
- Go to https://charmhub-io-2182.demos.haus/store.json and compare with https://charmhub.io/store.json
- Go to https://charmhub-io-2182.demos.haus/hacluster/card.json and compare with https://charmhub.io/hacluster/card.json
- Go to https://charmhub-io-2182.demos.haus/hacluster/card.json and compare with https://charmhub.io/hacluster/card.json
- 
#### Locally
- Check out this branch and run `dotrun`
- In another terminal, run `cd cache` run `docker compose run redis-cli` , this would launch an interactive environment
- Then in your browser:
    -  go to `localhost:8045/store.json`: this would take the usual long time to load on first instance
    - refresh the page and take note that it is faster
    - add query param `?page=2`, try this for different pages and check that it loads fast, the pages should be served from the cache of the first page load
    - then go to `localhost:8045/kafka/card.json` , the first load would take a while, refresh and it should be very fast
    - also try with `localhost:8045/mongodb/card.json` and `localhost:8045/hacluster/card.json`,  (you can test with any package of your choice)
    
   - To confirm that all the above pages were cached, go to your interactive redis-cli terminal and type `KEYS *`, you should see all the cached keys

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why):

## Issue / Card
Fixes #

## Screenshots
