### PR TITLE
add kafka and kafka-k8s redirects

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -36,3 +36,5 @@ postgresql/docs/(?P<path>.*)/?: https://canonical-charmed-postgresql.readthedocs
 postgresql-k8s/docs/(?P<path>.*)/?: https://canonical-charmed-postgresql-k8s.readthedocs-hosted.com/14/{path}/
 mysql/docs/(?P<path>.*)/?: https://canonical-charmed-mysql.readthedocs-hosted.com/{path}/
 mysql-k8s/docs/(?P<path>.*)/?: https://canonical-charmed-mysql-k8s.readthedocs-hosted.com/{path}/
+kafka/docs/(?P<path>.*)/?: https://documentation.ubuntu.com/charmed-kafka/3/{path}/
+kafka-k8s/docs/(?P<path>.*)/?: https://documentation.ubuntu.com/charmed-kafka-k8s/3/{path}/


### PR DESCRIPTION
## Done
- Adds wildcard redirects from kafka and kafka-k8s to RTD

## How to QA
- Click on multiple docs links at https://charmhub-io-2186.demos.haus/kafka
  - Make sure you're redirected to the corresponding RTD  
- Do the same for https://charmhub-io-2186.demos.haus/kafka-k8s

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): adding redirects

## Issue / Card
Fixes [WD-26230](https://warthogs.atlassian.net/browse/WD-26230)

[WD-26230]: https://warthogs.atlassian.net/browse/WD-26230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ