### PR TITLE
show highest revision in channel map dropdown

### DIFF
--- a/static/js/src/public/details/__tests__/channelMap.test.ts
+++ b/static/js/src/public/details/__tests__/channelMap.test.ts
@@ -31,6 +31,7 @@ describe("channelMap", () => {
     selectedEl = document.createElement("div");
     selectedEl.setAttribute("data-channel-map-track", "latest");
     selectedEl.setAttribute("data-channel-map-channel", "stable");
+    selectedEl.setAttribute("data-channel-map-version", "1.0.0");
     selectedEl.setAttribute("data-channel-map-arch-filter", "arm64");
 
     archFilterEl = document.createElement("select");
@@ -60,10 +61,10 @@ describe("channelMap", () => {
     document.body.appendChild(selectedEl);
 
     channelsToBeFiltered = [
-      createChannelElement("latest", "stable", "arm64", "20.04"),
-      createChannelElement("latest", "candidate", "amd64", "18.04"),
-      createChannelElement("2.0", "stable", "arm64", "20.04"),
-      createChannelElement("2.0", "candidate", "arm64", "20.04"),
+      createChannelElement("latest", "stable", "1.0.0", "arm64", "20.04"),
+      createChannelElement("latest", "candidate", "1.1.0", "amd64", "18.04"),
+      createChannelElement("2.0", "stable", "2.0.0", "arm64", "20.04"),
+      createChannelElement("2.0", "candidate", "2.1.0", "arm64", "20.04"),
     ];
 
     channelsToBeFiltered.forEach((el) => channelMapContentEl.appendChild(el));
@@ -106,7 +107,7 @@ describe("channelMap", () => {
 
     await waitFor(() => {
       const selected = document.querySelector(
-        `[data-channel-map-track="latest"][data-channel-map-channel="stable"]`
+        `[data-channel-map-track="latest"][data-channel-map-channel="stable"][data-channel-map-version="1.0.0"]`
       );
       expect(selected).not.toBeNull();
       expect(selected?.classList.contains("is-active")).toBe(true);
@@ -179,12 +180,14 @@ describe("channelMap", () => {
   function createChannelElement(
     track: string,
     channel: string,
+    version: string,
     arch: string,
     base: string
   ): HTMLElement {
     const el = document.createElement("div");
     el.setAttribute("data-channel-map-track", track);
     el.setAttribute("data-channel-map-channel", channel);
+    el.setAttribute("data-channel-map-version", version);
     el.setAttribute("data-channel-map-arch-filter", arch);
     el.setAttribute("data-channel-map-base-filter", base);
     return el;

--- a/static/js/src/public/details/channelMap.ts
+++ b/static/js/src/public/details/channelMap.ts
@@ -53,7 +53,7 @@ const init = (packageName: string, channelMapButton: HTMLElement) => {
     }
 
     const selected = document.querySelector(
-      `[data-channel-map-track="${track}"][data-channel-map-channel="${channel}"]`
+      `[data-channel-map-track="${track}"][data-channel-map-channel="${channel}"][data-channel-map-version="${channelMapState.version}"]`
     );
 
     selected?.classList.add("is-active");
@@ -102,17 +102,46 @@ const init = (packageName: string, channelMapButton: HTMLElement) => {
   });
 
   function hideOlderChannels() {
-    const seen = new Set();
+    const channelRevisions = new Map();
+
+    // find the highest revision for each channel
     channelsToBeFiltered.forEach((el) => {
-      const track = `${el.getAttribute("data-channel-map-track")}${el.getAttribute("data-channel-map-channel")}`;
       if (el.classList.contains("u-hide")) {
         return;
       }
 
-      if (seen.has(track)) {
+      const track = el.getAttribute("data-channel-map-track");
+      const channel = el.getAttribute("data-channel-map-channel");
+      const version = el.getAttribute("data-channel-map-version");
+
+      if (!track || !channel || !version) return;
+
+      const trackChannel = `${track}${channel}`;
+
+      if (
+        !channelRevisions.has(trackChannel) ||
+        parseInt(version) > parseInt(channelRevisions.get(trackChannel)!)
+      ) {
+        channelRevisions.set(trackChannel, version);
+      }
+    });
+
+    // hide revisions that aren't the highest
+    channelsToBeFiltered.forEach((el) => {
+      if (el.classList.contains("u-hide")) {
+        return;
+      }
+
+      const track = el.getAttribute("data-channel-map-track");
+      const channel = el.getAttribute("data-channel-map-channel");
+      const version = el.getAttribute("data-channel-map-version");
+
+      if (!track || !channel || !version) return;
+
+      const trackChannel = `${track}${channel}`;
+
+      if (version !== channelRevisions.get(trackChannel)) {
         el.classList.add("u-hide");
-      } else {
-        seen.add(track);
       }
     });
   }


### PR DESCRIPTION
## Done
- Fixes bug where channel map dropdown was showing the wrong revision compared to the default
- Changed `hideOlderChannels` logic to show the highest revision of a channel instead of the first one that is found

## How to QA
- Go to https://charmhub-io-2187.demos.haus/nginx-ingress-integrator
- Make sure the default revision is also the revision showing in the dropdown (153)
  - Compare with prod (or staging right now because prod is down) - https://staging.charmhub.io/nginx-ingress-integrator

## Testing
- [x] This PR has tests: updates existing tests
- [ ] No testing required (explain why): bug fix

## Issue / Card
Fixes [WD-26660](https://warthogs.atlassian.net/browse/WD-26660)


[WD-26660]: https://warthogs.atlassian.net/browse/WD-26660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ