### PR TITLE
add redis cache to search

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -14,7 +14,6 @@ from webapp.publisher.views import publisher
 from webapp.store.views import store
 from webapp.integrations.views import integrations
 from webapp.search.views import search
-from webapp.search.logic import cache
 from webapp.helpers import markdown_to_html
 from webapp.decorators import login_required
 from webapp.packages.store_packages import store_packages
@@ -42,7 +41,6 @@ set_handlers(app)
 
 request_session = requests.Session()
 candid = CandidClient(request_session)
-cache.init_app(app)
 csrf.init_app(app)
 
 app.register_blueprint(store_packages)


### PR DESCRIPTION
## Done
- Remove simple cache from search
- Add redis cache
## How to QA
- Go to:
    - /all-search.json?q=juju
    - all-docs?q=database
    - all-topics?q=cloud
    - all-charms?q=kafka
    - all-bundles?q=cos
    - for each of the visited routes, reload and check that it loads faster than the first time
- Also go to /all-search?q=juju or simply search for a term from the landing page

#### To QA Locally
- `cd redis_cache` and run `docker compose run redis-cli`, this will open the interactive window
- In another terminal, run `dotrun` as usual,
    - visit:
        - localhost:8045/all-search.json?q=juju
        - localhost:8045/all-docs?q=database
        - localhost:8045/all-topics?q=cloud
        - localhost:8045/all-charms?q=kafka
        - localhost:8045/all-bundles?q=cos
  
## Testing
- [ ] This PR has tests
- [x] No testing required (explain why):

## Issue / Card WD-26030
Fixes #

## Screenshots
