### PR TITLE
Remove unused logic from store page

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ beautifulsoup4==4.12.3
 canonicalwebteam.candid==0.9.0
 canonicalwebteam.discourse==6.3.0
 canonicalwebteam.image-template==1.8.0
-canonicalwebteam.store-api==7.3.0
+canonicalwebteam.store-api==7.3.1
 canonicalwebteam.docstring-extractor==1.2.0
 
 Flask-WTF==1.2.2

--- a/webapp/packages/logic.py
+++ b/webapp/packages/logic.py
@@ -44,9 +44,10 @@ def get_icon(media):
 
 @trace_function
 def fetch_packages(
-    fields: List[str], query_params: Dict[str, Any]) -> list[Package]:
+    fields: List[str], query_params: Dict[str, Any]
+) -> list[Package]:
     """
-    Fetches and parses packages from the store API based on the specified fields.
+    Fetches and parses packages from the store API.
 
     :param: fields (List[str]): A list of fields to include in the package
     data.
@@ -92,12 +93,10 @@ def fetch_packages(
                 filtered_packages.append(p)
         packages = filtered_packages
 
-    result = [
-        parse_package_for_card(package) for package in packages
-    ]
+    result = [parse_package_for_card(package) for package in packages]
     redis_cache.set(key, result, ttl=600)
 
-    return result         
+    return result
 
 
 @trace_function

--- a/webapp/packages/logic.py
+++ b/webapp/packages/logic.py
@@ -44,29 +44,21 @@ def get_icon(media):
 
 @trace_function
 def fetch_packages(
-    fields: List[str], query_params: Dict[str, Any], libraries: bool = False
-) -> Packages:
+    fields: List[str], query_params: Dict[str, Any]) -> list[Package]:
     """
-    Fetches packages from the store API based on the specified fields
-    and parse the packages.
+    Fetches and parses packages from the store API based on the specified fields.
 
     :param: fields (List[str]): A list of fields to include in the package
     data.
     :param: query_params: A search query
 
-    :returns: a dictionary containing the list of parsed packages.
+    :returns: a list of parsed packages.
     """
 
     category = query_params.get("categories", "")
     query = query_params.get("q", "")
     package_type = query_params.get("type", None)
     platform = query_params.get("platforms", "")
-    architecture = query_params.get("architecture", "")
-    provides = query_params.get("provides", None)
-    requires = query_params.get("requires", None)
-
-    if package_type == "all":
-        package_type = None
 
     args = {
         "category": category,
@@ -74,16 +66,8 @@ def fetch_packages(
         "query": query,
     }
 
-    if package_type:
+    if package_type and package_type != "all":
         args["type"] = package_type
-
-    if provides:
-        provides = provides.split(",")
-        args["provides"] = provides
-
-    if requires:
-        requires = requires.split(",")
-        args["requires"] = requires
 
     key = (
         "fetch-packages",
@@ -91,35 +75,29 @@ def fetch_packages(
             "category": category,
             "q": query,
             "platform": platform,
-            "arch": architecture,
             "type": package_type,
-            "lib": libraries,
         },
     )
-    result = redis_cache.get(key, expected_type=dict)
+    result = redis_cache.get(key, expected_type=list)
     if result:
-        return {"data": result}
+        return result
     packages = publisher_gateway.find(**args).get("results", [])
     if platform and platform != "all":
         filtered_packages = []
         for p in packages:
-            platforms = p["result"].get("deployable-on", [])
+            platforms = p.get("result", {}).get("deployable-on", [])
             if not platforms:
                 platforms = ["vm"]
             if platform in platforms:
                 filtered_packages.append(p)
         packages = filtered_packages
 
-    if architecture and architecture != "all":
-        args["architecture"] = architecture
-        packages = publisher_gateway.find(**args).get("results", [])
-
     result = [
-        parse_package_for_card(package, libraries) for package in packages
+        parse_package_for_card(package) for package in packages
     ]
     redis_cache.set(key, result, ttl=600)
 
-    return {"data": result}
+    return result         
 
 
 @trace_function
@@ -283,17 +261,13 @@ def paginate(
 
 @trace_function
 def get_packages(
-    libraries: bool,
     fields: List[str],
+    query_params: Dict[str, Any],
     size: int = 10,
-    query_params: Dict[str, Any] = {},
-) -> List[Dict[str, Any]]:
+) -> Dict[str, Any]:
     """
-    Retrieves a list of packages from the store based on the specified
-    parameters.The returned packages are paginated and parsed using the
-    card schema.
+    Retrieves a list of packages and paginate.
 
-    :param: store: The store object.
     :param: fields (List[str]): A list of fields to include in the
             package data.
     :param: size (int, optional): The number of packages to include
@@ -305,7 +279,7 @@ def get_packages(
             the total pages
     """
 
-    packages = fetch_packages(fields, query_params, libraries).get("data", [])
+    packages = fetch_packages(fields, query_params)
 
     total_pages = -(len(packages) // -size)
     total_items = len(packages)

--- a/webapp/packages/store_packages.py
+++ b/webapp/packages/store_packages.py
@@ -26,13 +26,11 @@ store_packages = Blueprint(
 @store_packages.route("/store.json")
 def get_store_packages():
     args = dict(request.args)
-    libraries = bool(args.pop("fields", ""))
-    res = make_response(
+    res = jsonify(
         get_packages(
-            libraries,
             FIELDS,
-            12,
             args,
+            12,
         )
     )
     return res

--- a/webapp/topics/views.py
+++ b/webapp/topics/views.py
@@ -116,7 +116,8 @@ class TopicParser(DocParser):
 @topics.route("/topics.json")
 def topics_json():
     query = request.args.get("q", default=None, type=str)
-    key = ("topics-json", ({"q": query}))
+    q = None if query in (None, "", "null") else query
+    key = ("topics-json", {"q": q})
     results = redis_cache.get(key, expected_type=list)
     if results:
         return jsonify(
@@ -164,7 +165,7 @@ def all_topics():
 @topics.route("/topics/<string:topic_slug>")
 @topics.route("/topics/<string:topic_slug>/<path:path>")
 def topic_page(topic_slug, path=None):
-    key = ("topic-page", ({"topic_slug": topic_slug, "path": path}))
+    key = ("topic-page", {"topic_slug": topic_slug, "path": path})
     cached_page = redis_cache.get(key, expected_type=dict)
     if cached_page:
         return render_template("topics/document.html", **cached_page)


### PR DESCRIPTION
## Done
- Update `store-api` version
- remove some unused logic that was leftover from when we had store-base module
- remove "null" getting appended to `topics-json` cache key when no query-param is specified
## How to QA
- Go to [Demo](https://charmhub-io-2202.demos.haus/), ensure that the store landing page load as expected, the topics should be displayed.
- Also, check that all filters work as expected
## Testing
- [ ] This PR has tests
- [x] No testing required (explain why):

## Issue / Card
Fixes #

## Screenshots
